### PR TITLE
ログイン機能実装（フロント）

### DIFF
--- a/back/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/back/app/controllers/api/v1/auth/sessions_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
   # DeviseTokenAuth:ApplicationControllerがincludeするconcerns/set_user_by_token.rbのset_cookieメソッドをオーバーライド
   def set_cookie(auth_header)
     # Cookieの有効期限カスタム設定
-    expires_in = params[:remember_me] == 'true' ? 2.weeks.from_now : 1.day.from_now
+    expires_in = params[:remember_me] ? 2.weeks.from_now : 1.day.from_now
     # カスタム設定をデフォルト設定にmergeでオーバーライド
     cookies[DeviseTokenAuth.cookie_name] = DeviseTokenAuth.cookie_attributes.merge({
       value: auth_header.to_json,

--- a/front/src/components/User/SignInForm.jsx
+++ b/front/src/components/User/SignInForm.jsx
@@ -1,9 +1,111 @@
 "use client";
 
-export function SignInForm (){
-  return(
-    <div>
-      テスト
-    </div>
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Box, TextField, FormControlLabel, Checkbox, Button, Divider, Alert } from "@mui/material";
+import LockIcon from '@mui/icons-material/Lock';
+import GoogleIcon from "@mui/icons-material/Google";
+import { PasswordField } from "./PasswordField";
+
+import { useSignInValidation } from "../../hooks/useSignInValidation";
+import { signInRequest } from "../../services/SignInRequest";
+
+export function SignInForm() {
+  const router = useRouter();
+  const [showPassword, setShowPassword] = useState(false);
+  const [formError, setFormError] = useState("");
+
+  const handleTogglePasswordVisibility = () => setShowPassword(!showPassword);
+
+  const { register, handleSubmit, setError, errors } = useSignInValidation();
+
+  const sendDataToAPI = async (data) => {
+    try {
+      const response = await signInRequest(data);
+      router.push("/post");
+    } catch (error) {
+      if (error.email) {
+        setError("email", { type: "manual", message: error.email });
+      } else if (error.password) {
+        setError("password", { type: "manual", message: error.password });
+      } else {
+        // 他の特定フィールドでのエラーがない場合、フォーム全体に対するエラーメッセージを設定
+        setFormError(error.general);
+      }
+    }
+  };
+
+  return (
+    <Box
+    component= "form"
+    onSubmit={handleSubmit(sendDataToAPI)}
+    sx={{
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      width: "80%",
+      gap: 3,
+      my: 3,
+    }}>
+      {formError && <Alert severity="error">{formError}</Alert>}
+      <Box
+        sx={{
+          width: 50,
+          height: 50,
+          borderRadius: "50%",
+          backgroundColor: "primary.main",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          borderColor: "primary.main",
+        }}
+      >
+        <LockIcon
+          sx={{
+            fontSize: 35,
+            color: "background.paper",
+          }}
+        />
+      </Box>
+      <Button variant="outlined" startIcon={<GoogleIcon />} fullWidth >
+      SIGN IN WITH GOOGLE
+      </Button>
+      <Divider variant="fullWidth">or</Divider>
+
+      <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 3,
+        width: "100%"
+      }}>
+        <TextField
+        label="メールアドレス"
+        variant="outlined"
+        placeholder="example@gmail.com"
+        fullWidth
+        {...register("email")}
+        error={!!errors.email}
+        helperText={errors.email?.message}
+        />
+        <PasswordField
+          label="パスワード"
+          placeholder="英数字8文字以上"
+          showPassword={showPassword}
+          onToggleVisibility={handleTogglePasswordVisibility}
+          {...register("password")}
+          error={!!errors.password}
+          helperText={errors.password?.message}
+        />
+        <FormControlLabel
+          control={<Checkbox {...register("remember_me")} />}
+          label="ログイン状態を保持する"
+        />
+        <Button type="submit" variant="contained" color="primary" fullWidth sx={{mt:2}}>
+          ログインする
+        </Button>
+      </Box>
+    </Box>
   );
 }

--- a/front/src/components/User/SignUpForm.jsx
+++ b/front/src/components/User/SignUpForm.jsx
@@ -27,16 +27,15 @@ export function SignUpForm() {
       const response = await signUpRequest(filteredData);
       router.push("/post");
     } catch (error) {
-      console.log(error);
-    if (error.errors?.email) {
-        setError("email", { type: "manual", message: error.errors.email[0] });
-      } else if (error.errors?.password) {
-        setError("password", { type: "manual", message: error.errors.password[0] });
-      } else if (error.errors?.username) {
-        setError("username", { type: "manual", message: error.errors.username[0] });
+    if (error.email) {
+        setError("email", { type: "manual", message: error.email });
+      } else if (error.password) {
+        setError("password", { type: "manual", message: error.password });
+      } else if (error.username) {
+        setError("username", { type: "manual", message: error.username });
       } else {
         // 他の特定フィールドでのエラーがない場合、フォーム全体に対するエラーメッセージを設定
-        setFormError("エラーが発生しました。再度お試しください。");
+        setFormError(error.general);
       }
     }
   };

--- a/front/src/hooks/useSignInValidation.jsx
+++ b/front/src/hooks/useSignInValidation.jsx
@@ -15,10 +15,15 @@ export const useSignInValidation = () => {
   const {
     register,
     handleSubmit,
+    setError,
     formState: { errors },
   } = useForm({
     resolver: yupResolver(schema),
+    defaultValues: {
+      remember_me: false,
+    },
+    mode: "onChange"
   });
 
-  return { register, handleSubmit, errors };
+  return { register, handleSubmit, setError, errors };
 };

--- a/front/src/services/SignInRequest.jsx
+++ b/front/src/services/SignInRequest.jsx
@@ -14,6 +14,10 @@ export const signInRequest = async (data) => {
       if (error.response.data.errors.password) {
         formattedErrors.password = error.response.data.errors.password[0];
       }
+    }
+
+    if (error.response?.status === 401 && error.response.data.errors) {
+        formattedErrors.general = "メールアドレスもしくはパスワードが正しくありません";
     } else {
       formattedErrors.general = "エラーが発生しました。再度お試しください。";
     }

--- a/front/src/services/SignUpRequest.jsx
+++ b/front/src/services/SignUpRequest.jsx
@@ -1,11 +1,25 @@
 import axios from 'axios';
-import { formatErrorMessage } from "./FormatErrorMessage";
 
 export const signUpRequest = async (data) => {
   try {
     const response = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/auth`, data);
     return response.data;
   } catch (error) {
-    throw formatErrorMessage(error.response?.data || error.message);
+    const formattedErrors = {};
+
+    if (error.response?.data?.errors) {
+      if (error.response.data.errors.email) {
+        formattedErrors.email = error.response.data.errors.email[0];
+      }
+      if (error.response.data.errors.password) {
+        formattedErrors.password = error.response.data.errors.password[0];
+      }
+      if (error.response.data.errors.username) {
+        formattedErrors.username = error.response.data.errors.username[0];
+      }
+    } else {
+      formattedErrors.general = "エラーが発生しました。再度お試しください。";
+    }
+    throw formattedErrors;
   }
 };


### PR DESCRIPTION
### 対応項目
- [x] ログインフォームの実装
- [x] ログインリクエストロジックの実装
- [x] ログインバリデーションロジックの実装

### 未対応項目
- [ ] Dividerが表示されない問題

### 留意事項
#### ログイン状態保持の判別に利用するremember_meはbooleanで管理する為、バックエンドのログインロジックの一部を変更

close #8 