### PR TITLE
BottomNaviからの遷移認証ロジック追加

### DIFF
--- a/front/src/components/Project/post_project/PostProjectStepper.jsx
+++ b/front/src/components/Project/post_project/PostProjectStepper.jsx
@@ -5,6 +5,7 @@ import { Stepper, Step, StepLabel, Box, Typography } from "@mui/material";
 import PostAddIcon from '@mui/icons-material/PostAdd';
 import { PostProjectStep1 } from "./PostProjectStep1";
 import { PostProjectStep2 } from "./PostProjectStep2";
+import { useRequireAuth } from "../../../context/useRequireAuth";
 
 const steps = ["録音", "投稿"];
 
@@ -12,6 +13,7 @@ export function PostProjectStepper(){
   const [activeStep, setActiveStep] = useState(0);
   const [audioBufferForPost, setAudioBufferForPost] = useState(null);
   const [settingsForPost, setSettingsForPost] = useState(null);
+  const isAuthenticated = useRequireAuth();
 
   //ステップ進行制御
   const handleNext = () => {
@@ -22,40 +24,42 @@ export function PostProjectStepper(){
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
-  return (
-    <Box sx={{m:2, p:2}}>
-      <Box sx={{display: "flex", alignItems: "center", justifyContent: "center"}}>
-        <PostAddIcon color="primary" sx={{ fontSize: "3rem"}} />
-        <Typography variant="h5" sx={{ color: "text.primary" }}>投稿画面</Typography>
-      </Box>
-      <Stepper activeStep={activeStep}
-              sx={{
-                justifyContent: "center",
-                width: "60%",
-                margin: "0 auto",
-                my:3
-              }}>
-        {steps.map((label => (
-          <Step key={label}>
-            <StepLabel>{label}</StepLabel>
-          </Step>
-        )))}
-      </Stepper>
+  if(isAuthenticated) {
+    return (
+      <Box sx={{m:2, p:2}}>
+        <Box sx={{display: "flex", alignItems: "center", justifyContent: "center"}}>
+          <PostAddIcon color="primary" sx={{ fontSize: "3rem"}} />
+          <Typography variant="h5" sx={{ color: "text.primary" }}>投稿画面</Typography>
+        </Box>
+        <Stepper activeStep={activeStep}
+                sx={{
+                  justifyContent: "center",
+                  width: "60%",
+                  margin: "0 auto",
+                  my:3
+                }}>
+          {steps.map((label => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          )))}
+        </Stepper>
 
-      <Box>
-        {activeStep === 0 &&
-        <PostProjectStep1
-        onNext={handleNext}
-        setAudioBufferForPost={setAudioBufferForPost}
-        setSettingsForPost={setSettingsForPost}
-        activeStep={activeStep}/>}
-        {activeStep === 1 &&
-        <PostProjectStep2
-        onBack={handleBack}
-        audioBufferForPost={audioBufferForPost}
-        settingsForPost={settingsForPost}
-        activeStep={activeStep} />}
+        <Box>
+          {activeStep === 0 &&
+          <PostProjectStep1
+          onNext={handleNext}
+          setAudioBufferForPost={setAudioBufferForPost}
+          setSettingsForPost={setSettingsForPost}
+          activeStep={activeStep}/>}
+          {activeStep === 1 &&
+          <PostProjectStep2
+          onBack={handleBack}
+          audioBufferForPost={audioBufferForPost}
+          settingsForPost={settingsForPost}
+          activeStep={activeStep} />}
+        </Box>
       </Box>
-    </Box>
-  );
+    );
+  }
 };

--- a/front/src/components/User/AuthPageWrapper.jsx
+++ b/front/src/components/User/AuthPageWrapper.jsx
@@ -7,7 +7,7 @@ import { AuthModal } from './AuthModal';
 export function AuthPageWrapper() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const redirectTo = searchParams.get("redirectTo") //直前のリクエストURL
+  const redirectTo = searchParams.get("redirectTo") || sessionStorage.getItem("redirectTo") || "/" //直前のリクエストURL
   const [openAuthModal, setOpenAuthModal] = useState(true);
 
   const handleClose = () => {

--- a/front/src/context/useAuthContext.js
+++ b/front/src/context/useAuthContext.js
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useState, useContext } from 'react';
+import React, { createContext, useState, useContext, useEffect } from 'react';
 
 const AuthContext = createContext();
 
@@ -8,6 +8,15 @@ export const AuthProvider = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [authenticatedUser, setAuthenticatedUser] = useState(null);
+
+  //初期化
+  useEffect(() => {
+    const storedUser = localStorage.getItem("authenticatedUser");
+    if (storedUser) {
+      setAuthenticatedUser(JSON.parse(storedUser));
+      setIsAuthenticated(true);
+    }
+  }, []);
 
   //ログイン成功時の関数
   const handleLoginSuccess = (user) => {

--- a/front/src/context/useRequireAuth.js
+++ b/front/src/context/useRequireAuth.js
@@ -1,0 +1,25 @@
+"use client";
+
+import { useAuthContext } from "./useAuthContext";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export function useRequireAuth() {
+  const { isAuthenticated, openAuthModal } = useAuthContext();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      console.warn("未認証状態です。ログイン画面へリダイレクトします。");
+
+      // 遷移しようとしたURLを保存する
+      const currentPath = window.location.pathname;
+      sessionStorage.setItem("redirectTo", currentPath);
+
+      openAuthModal();
+      router.replace("/auth");
+    }
+  }, [isAuthenticated, openAuthModal, router]);
+
+  return isAuthenticated;
+}


### PR DESCRIPTION
### 対応項目
- [ ] router.pushによる画面遷移の認証制御実装
- [ ] AuthModalによる認証後、BottomNaviで指定したリンクへのリダイレクト（セッションストレージで管理）

close #83 