### PR TITLE
Update devise_token_auth.rb

### DIFF
--- a/back/config/initializers/devise_token_auth.rb
+++ b/back/config/initializers/devise_token_auth.rb
@@ -5,7 +5,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+   config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.


### PR DESCRIPTION
認証エラー解消
### コメントアウトではデフォルトのtrueが適用されてしまうため、明示的にfalseを設定