### PR TITLE
サインイン後遷移の不具合対応

### DIFF
--- a/front/src/app/auth/page.tsx
+++ b/front/src/app/auth/page.tsx
@@ -1,4 +1,4 @@
-import { AuthPageWrapper } from '../../components/User/AuthPageWrapper';
+import { AuthPageWrapper } from '@User/AuthPageWrapper';
 import { Suspense } from'react';
 
 export default function AuthPage() {

--- a/front/src/components/Project/post_project/PostProjectStepper.tsx
+++ b/front/src/components/Project/post_project/PostProjectStepper.tsx
@@ -6,7 +6,7 @@ import { Stepper, Step, StepLabel, Box, Typography } from "@mui/material";
 import PostAddIcon from '@mui/icons-material/PostAdd';
 import { PostProjectStep1 } from "@Project/post_project/PostProjectStep1";
 import { PostProjectStep2 } from "@components/Project/post_project/PostProjectStep2";
-import { useRequireAuth } from "@context/useRequireAuth";
+// import { useRequireAuth } from "@context/useRequireAuth";
 
 const steps = ["録音", "投稿"];
 
@@ -17,7 +17,7 @@ export function PostProjectStepper(){
     tempo: 120,
     duration: 30,
   });
-  const isAuthenticated = useRequireAuth();
+  // const isAuthenticated = useRequireAuth();
 
   //ステップ進行制御
   const handleNext = () => {
@@ -28,7 +28,7 @@ export function PostProjectStepper(){
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
-  if(isAuthenticated) {
+  // if(isAuthenticated) {
     return (
       <Box sx={{m:1, p:1}}>
         <Box sx={{display: "flex", alignItems: "center", justifyContent: "center"}}>
@@ -65,5 +65,5 @@ export function PostProjectStepper(){
         </Box>
       </Box>
     );
-  }
+  // }
 };

--- a/front/src/components/User/SignInForm.tsx
+++ b/front/src/components/User/SignInForm.tsx
@@ -35,11 +35,13 @@ export function SignInForm({redirectTo} : {redirectTo:string}) {
       // router.push の前後でログを追加
       if (redirectTo) {
         console.log("Navigating to redirectTo:", redirectTo);
-        await router.push(redirectTo);
+        window.location.href = redirectTo;
+        // await router.push(redirectTo);
         console.log("Navigation to redirectTo completed successfully:", redirectTo);
       } else {
         console.log("No redirectTo provided, navigating to default /projects");
-        await router.push("/projects?refresh=true");
+        window.location.href = "/projects?refresh=true";
+        // await router.push("/projects?refresh=true");
         console.log("Navigation to default /projects completed successfully");
       }
 


### PR DESCRIPTION
### 対応項目
- [ ] middlewareが動作しない原因となっているリダイレクト時の（二度目の）router.pushについて現状サーバーリクエストを明示的に送る手段がないため、window.location.hrefを利用