### PR TITLE
Issue35 collaboration management back

### DIFF
--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -5,11 +5,7 @@ class ApplicationController < ActionController::API
 
   def upload_audio_file_to_s3(audio_file)
     #S3へアクセスするインスタンスを作成
-    s3 = Aws::S3::Resource.new(
-      access_key_id: Rails.application.credentials.dig(:aws, :access_key_id),
-      secret_access_key: Rails.application.credentials.dig(:aws, :secret_access_key),
-      region: 'ap-northeast-1'
-    )
+    s3 = initialize_s3_resource
     #S3インスタンスにバケット名を紐付け
     bucket = s3.bucket('jam-my')
     #ファイル名の指定。audio/filesという仮想フォルダを含める。original_filenameはaudio_fileのname属性の値を取得する
@@ -26,5 +22,29 @@ class ApplicationController < ActionController::API
 
     #S3からアップロード後のURLを取得。
     return obj.public_url
+  end
+
+  def delete_audio_file_from_s3(file_path)
+    s3 = initialize_s3_resource
+    bucket = s3.bucket('jam-my')
+
+    # ファイルの削除
+    begin
+      obj = bucket.object(file_path)
+      obj.delete
+    rescue Aws::S3::Errors::ServiceError => e
+      Rails.logger.error "S3削除エラー: #{e.message}"
+      raise "既存ファイルの削除に失敗しました"
+    end
+  end
+
+  private
+
+  def initialize_s3_resource
+    Aws::S3::Resource.new(
+      access_key_id: Rails.application.credentials.dig(:aws, :access_key_id),
+      secret_access_key: Rails.application.credentials.dig(:aws, :secret_access_key),
+      region: 'ap-northeast-1'
+    )
   end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       resources :projects, only: %i[ index create edit update destroy ] do
         resources :collaborations, only: %i[create]
         resources :collaboration_managements, only: %i[index]
+        resource :collaboration_managements, only: %i[update]
       end
     end
   end

--- a/front/src/components/CollaborationManagement/CollaborationManagementStep1.tsx
+++ b/front/src/components/CollaborationManagement/CollaborationManagementStep1.tsx
@@ -200,6 +200,12 @@ export function CollaborationManagementStep1({
       );
 
       setOpenSnackbar(true);
+
+      //各PlayBackContextの初期化
+      setIsPlaybackTriggered(false);
+      playbackTriggeredByRef.current = null;
+      setIsPlaybackReset(true);
+      playbackResetTriggeredByRef.current = "AddToSynthesisList";
     }catch (e) {
       console.log("合成リストへの追加に失敗しました");
     }

--- a/front/src/components/CollaborationManagement/CollaborationManagementStep2.tsx
+++ b/front/src/components/CollaborationManagement/CollaborationManagementStep2.tsx
@@ -307,10 +307,12 @@ export function CollaborationManagementStep2({
         <Button onClick={onBack} variant="primary">
           音声選択/編集
         </Button>
+        {synthesisList.length > 0  &&(
         <Button onClick={handleAudioMerge} variant="primary" disabled={loading}
           startIcon={loading && <CircularProgress size={24} />}>
           合成する
         </Button>
+        )}
       </Box>
       {/* 削除確認ダイアログ */}
       <Dialog open={openDialog} onClose={handleCloseDialog}>

--- a/front/src/components/Project/ProjectCard.tsx
+++ b/front/src/components/Project/ProjectCard.tsx
@@ -99,10 +99,12 @@ export function ProjectCard({
             </IconButton>
           </Box>
         )}
-        {project.isOwner ? (
-          <Button variant="secondary" onClick={() => handleCollaborationManagementRequest()}>応募管理</Button>
-        ) : (
-          <Button variant="secondary" onClick={() => handleCollaborationRequest()}>応募する</Button>
+        {project.attributes.status === "open" && (
+          project.isOwner ? (
+            <Button variant="secondary" onClick={() => handleCollaborationManagementRequest()}>応募管理</Button>
+          ) : (
+            <Button variant="secondary" onClick={() => handleCollaborationRequest()}>応募する</Button>
+          )
         )}
         <Box
           sx={{

--- a/front/src/hooks/services/project/collaboration_management/useCompleteCollaborationManagementRequest.ts
+++ b/front/src/hooks/services/project/collaboration_management/useCompleteCollaborationManagementRequest.ts
@@ -4,7 +4,7 @@ import { handleStatusErrors } from '@services/ErrorHandler';
 export const useCompleteCollaborationManagementRequest = () => {
   const completeCollaborationManagement = async (project_id: string, data: FormData): Promise<any> => {
     try {
-      const response = await axios.put(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/projects/${project_id}`, data, { withCredentials: true });
+      const response = await axios.put(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/projects/${project_id}/collaboration_managements`, data, { withCredentials: true });
       return response.data;
     } catch (error: any) {
       const formattedErrors: { [key: string]: string } = {};

--- a/front/src/sharedTypes/types.ts
+++ b/front/src/sharedTypes/types.ts
@@ -163,6 +163,8 @@ export interface PostSettings {
   export interface CollaborationManagementRequestData {
     "project[mode]": string;
     "project[audio_file]": File;
+    "project[project_id]":string | null;
+    "project[collaboration_ids][]": number[];
   }
 
   //LoginForm


### PR DESCRIPTION
### 対応項目
- [ ] フォームから送信された合成後音声ファイルを保存、終了に分けたアクションメソッドの実装
- [ ] 合成された応募音声のステータス変更、かつAudioFile削除ロジック実装
- [ ] ルーティング変更に伴う、フロント側のリクエストの変更
- [ ] ProjectCardのボタン切り替え調整
- [ ] 合成リストへ追加等のボタン押下時に、PlayBackContextの値を初期化する処理を追加

close #35 