### PR TITLE
Issue98 password reset

### DIFF
--- a/back/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/back/app/controllers/api/v1/auth/passwords_controller.rb
@@ -1,0 +1,100 @@
+class Api::V1::Auth::PasswordsController < DeviseTokenAuth::PasswordsController
+
+  #下記devise_token_authをオーバーライドするもの（フロントをNext.jsとしている状況に対応）
+  # https://github.com/lynndylanhurley/devise_token_auth/blob/master/app/controllers/devise_token_auth/passwords_controller.rb
+  def edit
+    #リセットトークンからユーザー(@resource)を特定
+    @resource = resource_class.with_reset_password_token(resource_params[:reset_password_token])
+
+    #リセットトークンの有効性検証
+    if @resource && @resource.reset_password_period_valid?
+      token = @resource.create_token unless require_client_password_reset_token?
+
+      # アカウント認証スキップ
+      @resource.skip_confirmation! if confirmable_enabled? && !@resource.confirmed_at
+      # 一時的にパスワード変更を許可
+      @resource.allow_password_change = true if recoverable_enabled?
+      @resource.save!
+
+      yield @resource if block_given?
+
+      # require_client_password_reset_tokenがtrue（リセットトークンクライアント管理）であれば認証なしで進める
+      if require_client_password_reset_token?
+        render json: {
+          success: true,
+          message: 'リセットトークンが有効です',
+          reset_password_token: resource_params[:reset_password_token]
+        }, status: :ok
+      # require_client_password_reset_tokenがfalseであれば認証状態を付与する
+      else
+        # クッキーセット
+        if DeviseTokenAuth.cookie_enabled
+          set_token_in_cookie(@resource, token)
+        end
+
+        # 認証トークンをヘッダーにセット
+        response.headers.merge!(@resource.create_new_auth_token(token.client))
+
+        # 成功をJSONで返す
+        render json: {
+          success: true,
+          message: 'リセットトークンが有効で、認証状態が設定されました'
+        }, status: :ok
+      end
+    else
+      render_edit_error
+    end
+  end
+
+  def update
+    # require_client_password_reset_tokenがtrueの場合は認証状態の付与準備
+    if require_client_password_reset_token? && resource_params[:reset_password_token]
+      @resource = resource_class.with_reset_password_token(resource_params[:reset_password_token])
+      return render_update_error_unauthorized unless @resource
+
+      @token = @resource.create_token
+    # require_client_password_reset_tokenがfalseの場合は認証状態を継続
+    else
+      @resource = set_user_by_token
+    end
+
+    return render_update_error_unauthorized unless @resource
+
+    # OAuthユーザーではないか検証
+    unless @resource.provider == 'email'
+      return render_update_error_password_not_required
+    end
+
+    # パスワードとパスワード確認のpramsが送られてきているか検証
+    unless password_resource_params[:password] && password_resource_params[:password_confirmation]
+      return render_update_error_missing_password
+    end
+
+    # パスワード変更処理および変更許可→不許可
+    if @resource.send(resource_update_method, password_resource_params)
+      @resource.allow_password_change = false if recoverable_enabled?
+      @resource.save!
+
+      yield @resource if block_given?
+      # 認証トークンをクッキーとヘッダーにセット
+      if DeviseTokenAuth.cookie_enabled
+        set_token_in_cookie(@resource, @token)
+      end
+      response.headers.merge!(@resource.create_new_auth_token(@token.client))
+      return render_update_success
+    else
+      return render_update_error
+    end
+  end
+
+  protected
+
+  def render_update_success
+    render json: {
+      success: true,
+      data: UserSerializer.new(@resource).serializable_hash,
+      message: I18n.t('devise_token_auth.passwords.successfully_updated')
+    }
+  end
+end
+

--- a/back/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/back/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>こんにちは、 <%= @resource.email %>様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>以下のリンクをクリックして、パスワードをリセットしてください</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>
+  <%= link_to 'パスワード変更', "#{Rails.configuration.x.reset_password_url}?reset_password_token=#{@token}",
+      style: 'display: inline-block; padding: 10px 20px; color: white; background-color: #007BFF; text-decoration: none; border-radius: 5px;' %>
+</p>

--- a/back/config/environments/development.rb
+++ b/back/config/environments/development.rb
@@ -97,5 +97,6 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000, protocol: 'https' }
   # 認証メールテンプレート用パス
   config.x.confirmation_url = "https://localhost:8000/auth/confirmed"
-
+  # パスワードリセットテンプレート用パス
+  config.x.reset_password_url = "https://localhost:8000/auth/reset_password"
 end

--- a/back/config/environments/production.rb
+++ b/back/config/environments/production.rb
@@ -111,4 +111,6 @@ Rails.application.configure do
   }
   # 認証メールテンプレート用パス
   config.x.confirmation_url = "https://www.jam-my.com/auth/confirmed"
+  # パスワードリセットテンプレート用パス
+  config.x.reset_password_url = "https://www.jam-my.com/auth/reset_password"
 end

--- a/back/config/initializers/devise_token_auth.rb
+++ b/back/config/initializers/devise_token_auth.rb
@@ -54,6 +54,12 @@ DeviseTokenAuth.setup do |config|
   #メール認証成功時のリダイレクト先（実質不要であるが、ロジック的に必要になる為）
   config.default_confirm_success_url = "https://www.jam-my.com/auth/confirmed"
 
+  #パスワードリセットを行うフロントのパス
+  config.default_password_reset_url = "https://www.jam-my.com/reset_password"
+
+  #リセットトークンをフロントに管理させる
+  config.require_client_password_reset_token = true
+
   # Makes it possible to use custom uid column
   # config.other_uid = "foo"
 

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'auth', controllers: {
     registrations: 'api/v1/auth/registrations',
     sessions: 'api/v1/auth/sessions',
-    confirmations: 'api/v1/auth/confirmations'
+    confirmations: 'api/v1/auth/confirmations',
+    passwords: 'api/v1/auth/passwords'
   }
   namespace :api do
     namespace :v1 do

--- a/front/src/app/auth/request_reset_password/page.tsx
+++ b/front/src/app/auth/request_reset_password/page.tsx
@@ -1,0 +1,11 @@
+import { RequestResetPassword } from '@User/RequestResetPassword';
+import { Suspense } from'react';
+
+export default function RequestResetPasswordPage() {
+
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <RequestResetPassword />
+    </Suspense>
+  );
+}

--- a/front/src/app/auth/reset_password/page.tsx
+++ b/front/src/app/auth/reset_password/page.tsx
@@ -1,0 +1,11 @@
+import { ResetPassword } from '@User/ResetPassword';
+import { Suspense } from'react';
+
+export default function ResetPasswordPage() {
+
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <ResetPassword />
+    </Suspense>
+  );
+}

--- a/front/src/components/User/AuthPending.tsx
+++ b/front/src/components/User/AuthPending.tsx
@@ -8,7 +8,7 @@ export const AuthPending = () => {
   return (
     <Box textAlign="center" sx={{mt:8, mx:2}}>
       <Typography variant="h5" gutterBottom>
-        ご登録ありがとうございます！
+        JamMyへご登録ありがとうございます！
       </Typography>
       <Typography>
         以下のメールアドレスに認証リンクを送信しました
@@ -17,7 +17,7 @@ export const AuthPending = () => {
         {email}
       </Typography>
       <Typography mt={3}>
-        メールを確認し、リンクをクリックしてアカウントを有効化してください。
+        メールを確認し、アカウントを有効化してください。
       </Typography>
     </Box>
   );

--- a/front/src/components/User/RequestResetPassword.tsx
+++ b/front/src/components/User/RequestResetPassword.tsx
@@ -1,0 +1,85 @@
+"use client";
+import React, { useState } from 'react';
+import axios from 'axios';
+import { TextField, Button, Alert, Typography, Box, Container } from '@mui/material';
+
+export const RequestResetPassword = () => {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    try {
+      await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/auth/password`, { email });
+      setMessage('リセットリンクをメールに送信しました。メールをご確認の上、パスワードの変更をしてください');
+      setError(null);
+    } catch (err) {
+      setError('リセットリンクの送信に失敗しました。もう一度お試しください。');
+      setMessage(null);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 8 }}>
+      <Box
+        sx={{
+          textAlign: 'center',
+          bgcolor: 'background.paper',
+          p: 4,
+          borderRadius: 2,
+          boxShadow: 3,
+        }}
+      >
+        <Typography variant="h5" component="h1" gutterBottom>
+          パスワードリセット
+        </Typography>
+        <Typography variant="body1" color="text.secondary" gutterBottom>
+          登録済みのメールアドレスを入力してください。リセットリンクをお送りします。
+        </Typography>
+        <Box
+          component="form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            mt: 2,
+          }}
+        >
+          <TextField
+            label="メールアドレス"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            fullWidth
+            required
+          />
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            fullWidth
+            sx={{
+              textTransform: 'none',
+              fontWeight: 'bold',
+            }}
+          >
+            リセットリンクを送信
+          </Button>
+        </Box>
+        {message && (
+          <Alert severity="success" sx={{ mt: 3 }}>
+            {message}
+          </Alert>
+        )}
+        {error && (
+          <Alert severity="error" sx={{ mt: 3 }}>
+            {error}
+          </Alert>
+        )}
+      </Box>
+    </Container>
+  );
+};

--- a/front/src/components/User/ResetPassword.tsx
+++ b/front/src/components/User/ResetPassword.tsx
@@ -1,0 +1,151 @@
+"use client";
+import { ResetPasswordFormData, SignUpRequestData } from "@sharedTypes/types";
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import { useSearchParams } from 'next/navigation';
+import { TextField, Button, Alert, Typography, Box, Container } from '@mui/material';
+import { useResetPasswordValidation } from "@validation/useResetPasswordValidation";
+import { PasswordField } from "@User/PasswordField";
+import { useAuthContext } from "@context/useAuthContext";
+
+export const ResetPassword = () => {
+  const searchParams = useSearchParams();
+  const resetToken = searchParams.get('reset_password_token');
+
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordConfirmation, setShowPasswordConfirmation] = useState(false);
+  const [isTokenValid, setIsTokenValid] = useState<boolean>(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+
+  const { register, handleSubmit, setError: setValidationError, errors } = useResetPasswordValidation();
+  const { handleLoginSuccess } = useAuthContext();
+
+  const handleTogglePasswordVisibility = () => setShowPassword(!showPassword);
+  const handleTogglePasswordConfirmationVisibility = () =>
+    setShowPasswordConfirmation(!showPasswordConfirmation);
+
+  //devise_token_auth : editアクション
+  useEffect(() => {
+    const resetPasswordInit = async () => {
+      try {
+        const response = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_URL}/auth/password/edit`,
+          {
+            params: { reset_password_token: resetToken, },
+          }
+        );
+        setIsTokenValid(true);
+      } catch (error) {
+        setIsTokenValid(false);
+        setError("パスワードリセットのリクエストに失敗しました。");
+      }
+    };
+
+    if (resetToken) {
+      resetPasswordInit();
+    } else {
+      setError("正しいリンクからの遷移ではありません。");
+    }
+  }, []);
+
+  //Devise_token_auth: updateアクション
+  const resetPasswordRequest = async (data: ResetPasswordFormData) => {
+    try {
+      const response = await axios.put(`${process.env.NEXT_PUBLIC_API_URL}/auth/password`, {
+        reset_password_token: resetToken,
+        password: data.password,
+        password_confirmation: data.confirmPassword,
+      },{withCredentials: true});
+
+      handleLoginSuccess(response.data.data);
+      setMessage('パスワードがリセットされました。');
+      setError(null);
+      window.location.href = "/projects?refresh=true";
+    } catch (err: any) {
+      if (err.response?.data?.errors) {
+        setValidationError("password", {
+          type: "manual",
+          message: err.response.data.errors[0] || "パスワードリセットに失敗しました。",
+        });
+      } else {
+        setError("パスワードリセットに失敗しました。");
+      }
+    }
+  };
+
+  // トークンが無効の場合のメッセージ
+  if (!isTokenValid && error) {
+    return (
+      <Container maxWidth="sm" sx={{ mt: 8 }}>
+        <Box
+          sx={{
+            textAlign: "center",
+            bgcolor: "background.paper",
+            p: 4,
+            borderRadius: 2,
+            boxShadow: 3,
+          }}
+        >
+          <Typography variant="h5" component="h1" gutterBottom sx={{ mb: 3 }}>
+            パスワードリセットエラー
+          </Typography>
+          <Alert severity="error">{error}</Alert>
+        </Box>
+      </Container>
+    );
+  }
+
+  //フォーム
+  return (
+    <Container maxWidth="sm" sx={{ mt: 8 }}>
+      <Box
+        sx={{
+          textAlign: 'center',
+          bgcolor: 'background.paper',
+          p: 4,
+          borderRadius: 2,
+          boxShadow: 3,
+        }}
+      >
+        <Typography variant="h5" component="h1" gutterBottom sx={{mb:3}}>
+          パスワードリセット
+        </Typography>
+        {message && (
+          <Alert severity="success" sx={{ mb: 3 }}>
+            {message}
+          </Alert>
+        )}
+        <form onSubmit={handleSubmit(resetPasswordRequest)}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 16,
+        }}>
+          <PasswordField
+            label="新しいパスワード"
+            placeholder="英数字8文字以上"
+            showPassword={showPassword}
+            onToggleVisibility={handleTogglePasswordVisibility}
+            {...register("password")}
+            error={!!errors.password}
+            helperText={errors.password?.message}
+          />
+          <PasswordField
+            label="パスワード確認"
+            placeholder="英数字8文字以上"
+            showPassword={showPasswordConfirmation}
+            onToggleVisibility={handleTogglePasswordConfirmationVisibility}
+            {...register("confirmPassword")}
+            error={!!errors.confirmPassword}
+            helperText={errors.confirmPassword?.message}
+          />
+          <Button type="submit" variant="contained" color="primary" fullWidth>
+            パスワードをリセット
+          </Button>
+        </form>
+      </Box>
+    </Container>
+  );
+};

--- a/front/src/components/User/SignInForm.tsx
+++ b/front/src/components/User/SignInForm.tsx
@@ -3,6 +3,7 @@
 import { LoginFormData } from "@sharedTypes/types";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from 'next/link';
 import { Box, TextField, FormControlLabel, Checkbox, Button, Divider, Alert, Typography } from "@mui/material";
 import LockIcon from '@mui/icons-material/Lock';
 import GoogleIcon from "@mui/icons-material/Google";
@@ -119,9 +120,22 @@ export function SignInForm({redirectTo} : {redirectTo:string}) {
           control={<Checkbox {...register("remember_me")} />}
           label="ログイン状態を保持する"
         />
+        <Typography
+          variant="body2"
+          color="primary"
+          sx={{
+            cursor: "pointer",
+            '&:hover': { textDecoration: 'underline' },
+          }}
+          component={Link}
+          href="/auth/request_reset_password"
+        >
+          パスワードをお忘れですか？
+        </Typography>
         <Button type="submit" variant="contained" color="primary" fullWidth sx={{mt:2}}>
           ログインする
         </Button>
+
       </Box>
     </Box>
   );

--- a/front/src/hooks/validation/useResetPasswordValidation.ts
+++ b/front/src/hooks/validation/useResetPasswordValidation.ts
@@ -1,0 +1,31 @@
+import { ResetPasswordFormData } from "@sharedTypes/types";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+
+const schema = yup.object().shape({
+  password: yup
+    .string()
+    .required('パスワードは必須です')
+    .min(8, 'パスワードは8文字以上で入力してください')
+    .max(128, 'パスワードは128以下で入力してください')
+    .matches(/^[a-zA-Z0-9]*$/, '特殊文字は使用できません'),
+  confirmPassword: yup
+    .string()
+    .required('パスワード確認は必須です')
+    .oneOf([yup.ref('password'), null as unknown as string], 'パスワードが一致しません'),
+});
+
+export const useResetPasswordValidation = () => {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<ResetPasswordFormData>({
+    resolver: yupResolver(schema),
+    mode: "onChange"
+  });
+
+  return { register, handleSubmit, setError, errors };
+};

--- a/front/src/sharedTypes/types.ts
+++ b/front/src/sharedTypes/types.ts
@@ -225,6 +225,12 @@ export interface PostSettings {
     general?: string;
   }
 
+  //ResetPassword
+  export interface ResetPasswordFormData {
+    password: string;
+    confirmPassword: string;
+  }
+
 //Context用
 
   // Context 用の型定義


### PR DESCRIPTION
### 対応項目
- [ ] パスワードリセット申請画面の実装
- [ ] パスワードリセットフォームの実装
- [ ] メールテンプレートおよび、設定ファイル等作成
- [ ] devise_token_authのpasswords_controllerをオーバーライド（デフォルトのリダイレクトの挙動を変更）
- [ ] メール認証UIの微調整、型定義。

### 未対応項目
- [ ] 本番環境チェック

close #98 