### PR TITLE
ShowページのSWR化と各アクションへの適用

### DIFF
--- a/front/next.config.ts
+++ b/front/next.config.ts
@@ -2,7 +2,7 @@ import { NextConfig } from "next";
 import path from "path";
 
 const nextConfig: NextConfig = {
-  // reactStrictMode: false,
+  reactStrictMode: false,
   async headers() {
     return [
       {

--- a/front/src/components/Project/ProjectShowWrapper.tsx
+++ b/front/src/components/Project/ProjectShowWrapper.tsx
@@ -10,22 +10,34 @@ import { AudioController } from "@Project/AudioController"
 import { useFetchAudioData } from "@audio/useFetchAudioData";
 import { applyIsOwnerToProjects } from "@utils/applyIsOwnerToProjects";
 import { useProjectComments } from "@services/swr/useCommentSWR";
+import { useShowProject } from "@services/swr/useShowProjectSWR";
 import { CommentForm } from "@Project/comment/CommentForm";
+import { useSWRConfig } from "swr";
 
 
 export function ProjectShowWrapper(){
   const { projectId } = useParams<Record<string, string>>();
 
   //SWR関連
+  const {
+    projects,
+    isLoading: isProjectLoading,
+    isError: isProjectError,
+    mutate: mutateProject
+  } = useShowProject(projectId);
+  console.log("useShowProjectが取得したキャッシュ", projects);
+
   const { comments, meta, hasMore, loadMore, isLoading, isError,isValidating,  mutate } = useProjectComments(projectId);
   console.log("SWRが取得したComments", comments);
+
+  const { cache } = useSWRConfig();
+  console.log("Showのcache", cache);
+
+
 
   const [isAudioControllerVisible, setAudioControllerVisible] = useState<boolean>(false);
   const [audioUrl, setAudioUrl] = useState<string | null>(null);
   const [audioData, setAudioData] = useState<ArrayBuffer | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-  const [projects, setProjects] = useState<EnrichedProject[]>([]);
   // console.log("projects追跡",projects);
 
   //オーディオコントローラーに使用
@@ -38,26 +50,6 @@ export function ProjectShowWrapper(){
 
   //context
 
-  //初期化処理
-  useEffect(() => {
-    const fetchProject = async () => {
-      try {
-        const res = await fetch(`/api/projects/${projectId}`);
-        const projects: InitialProjectData[] = await res.json();
-        const enrichedProjects = applyIsOwnerToProjects(projects);
-        setProjects(enrichedProjects);
-      } catch (err) {
-        setError("データの取得に失敗しました");
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchProject();
-
-    return () => {
-      setProjects([]);
-    }
-  }, [projectId]);
 
   // コメントへの返信処理
   const handleReply = (commentId: string) => {
@@ -99,7 +91,7 @@ export function ProjectShowWrapper(){
   };
 
   // 初期ロード中の表示
-  if (loading) {
+  if (isLoading) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100vh" }}>
         <CircularProgress />
@@ -107,10 +99,10 @@ export function ProjectShowWrapper(){
     );
   }
 
-  if (error) {
+  if (isError) {
     return (
       <Box sx={{ mx: 2, my: 4 }}>
-        <Alert severity="error">{error}</Alert>
+        <Alert severity="error">{isError}</Alert>
       </Box>
     );
   }
@@ -130,8 +122,6 @@ export function ProjectShowWrapper(){
           key={project.attributes.id}
           onPlayClick={handlePlayClick}
           project={project}
-          projects={projects}
-          setProjects={setProjects}
           />
         ))
       )}

--- a/front/src/components/Project/comment/CommentCard.tsx
+++ b/front/src/components/Project/comment/CommentCard.tsx
@@ -10,6 +10,8 @@ import { formatDistanceToNow } from "date-fns";
 import { ja } from "date-fns/locale";
 import { useCommentRequest } from "@services/project/feedback/useCommentRequest";
 import { useProjectComments } from "@services/swr/useCommentSWR";
+import { useProjectList } from "@services/swr/useProjectSWR";
+import { useSWRConfig } from "swr";
 
 export function CommentCard({
   comment,
@@ -21,7 +23,10 @@ export function CommentCard({
   projectId: string;
 }) {
   // SWR関連
-  const { mutate } = useProjectComments(projectId);
+  const { mutate } = useProjectComments(projectId); //コメント
+  const { mutate: indexMutate } = useProjectList(); //一覧
+  const { mutate: globalMutate } = useSWRConfig()
+  const detailMutateKey = `/api/projects/${projectId}`;
 
   // 状態管理
   const [openDeleteDialog, setOpenDeleteDialog] = useState<boolean>(false);
@@ -48,7 +53,9 @@ export function CommentCard({
   //削除ボタン
   const handleDeleteComment = async () =>{
     await deleteCommentProject(projectId, comment.id)
-    mutate();
+    mutate(); //コメントのSWR
+    globalMutate(detailMutateKey);
+    indexMutate(undefined, {revalidate: true}); //一覧SWR
   }
 
   return (

--- a/front/src/hooks/services/project/feedback/useBookmarkToggle.ts
+++ b/front/src/hooks/services/project/feedback/useBookmarkToggle.ts
@@ -6,24 +6,20 @@ import { useSWRConfig } from "swr";
 
 
 
-export const useBookmarkToggle = (
-  { projects,
-    setProjects
-  } : {
-    projects?: EnrichedProject[]
-    setProjects?: SetState<EnrichedProject[]>;
-  }) => {
+export const useBookmarkToggle = () => {
   const { bookmarkProject, unBookmarkProject } = useBookmarkRequest();
   const { cache } = useSWRConfig();
   const findPageKeyByProjectId = useFindPageKeyByProjectId();
   const applyMutate = useApplyMutate();
 
   //初期化変数
-  let isShowMode:boolean;
-  let result:PageKeyResult;
-  let mutateKey:string;
-  let projectIndex:number;
-  let targetProject:EnrichedProject;
+  let isShowMode: boolean;
+  let result:PageKeyResult | undefined;
+  let detailMutateKey:string | undefined;
+  let listMutateKey:string | undefined;
+  let projectIndex:number | undefined;
+  let targetProject:EnrichedProject | undefined;
+  let showTargetProjects:EnrichedProject | undefined;
 
 
   // Projects更新関数（上書き用のオブジェクト作成）
@@ -43,98 +39,47 @@ export const useBookmarkToggle = (
   };
 
 
-  // Showのprojects更新関数
-  const applyShowProject = (
-    updatedProject: EnrichedProject,
-    mutateKey: string,
-    projectIndex: number,
-    isShowMode: boolean,
-    projectId: string,
-    isBookmarkMode: boolean,
-    relatedId?: string
-  ) => {
-    if (!isShowMode) {
-      if (!mutateKey || projectIndex === undefined) {
-        console.error("キャッシュが初期化されていません");
-        return;
-      }
-      const createApiRequest = isBookmarkMode ? bookmarkProject : undefined;
-      const destroyApiRequest = !isBookmarkMode ? unBookmarkProject : undefined;
-      const finalizeData = isBookmarkMode ? createFinalizeProjects : destroyFinalizeProjects;
-
-      applyMutate({
-        updatedProject,
-        mutateKey,
-        projectIndex,
-        projectId,
-        createApiRequest,
-        destroyApiRequest,
-        finalizeData,
-        relatedId,
-      });  // 一覧ページを一度でも表示した場合は一覧用キャッシュも更新
-    }
-    // Show自身のコレクションの更新
-    if (setProjects) {
-      setProjects([updatedProject]);
-    }
-  };
-
-  //キャッシュ後のShowページの終了処理
-  const updateShowProjectFromCache = (
-    updatedProject: EnrichedProject,
-    mutateKey: string,
-    projectIndex: number,
-    setProjects?: SetState<EnrichedProject[]>
-  ) => {
-    const cacheData = cache.get(mutateKey);
-    console.log("詳細ページが終了処理をする為に取得したcacheData: " + cacheData);
-
-    if (!cacheData || !Array.isArray(cacheData.data.projects)) {
-      console.error("指定されたmutateKeyからのデータ取得に失敗しました。");
-      return;
-    }
-
-    const updatedCacheProject = cacheData.data.projects[projectIndex];
-
-    if (!updatedCacheProject) {
-      console.error("キャッシュから最新のプロジェクトデータが取得できませんでした。");
-      return;
-    }
-    const realBookmarkId = updatedCacheProject.attributes.current_bookmark_id;
-    const finalizedProject = createUpdatedProject(updatedProject, updatedCacheProject.attributes.bookmarked_by_current_user, realBookmarkId || null);
-
-    if (setProjects) {
-      setProjects([finalizedProject]);
-    }
-  };
-
-
   //初期化処理
-  const initialize = (projectId: string) => {
-    const projectListCacheKey = '/api/projects?page=1';
-    const hasProjectListCache = cache.get(projectListCacheKey) !== undefined;
-    isShowMode = !hasProjectListCache; //一覧キャッシュがない場合、つまり初回にShowリンクを踏み、投稿一覧ページにアクセスしていない（SWRを初期化していない）場合
-    if (!isShowMode){
-      result = findPageKeyByProjectId(projectId);
-      mutateKey = result.mutateKey;
+  const initialize = (projectId: string, mode:"list" | "detail" ) => {
+    result = findPageKeyByProjectId(projectId);
+    if (result){
+      listMutateKey = result.mutateKey;
       projectIndex = result.projectIndex;
     }
 
-    targetProject = isShowMode ? projects![0] : result?.project //ShowModeの際は対象のオブジェクトをそのまま取得する
+    isShowMode = mode === "detail"? true : false;
+    const hasProjectShowCache = cache.get(`/api/projects/${projectId}`) !== undefined;
+    // 詳細ページの mutateKey を設定（キャッシュがなければ undefined）
+    detailMutateKey = hasProjectShowCache ? `/api/projects/${projectId}` : undefined;
+
+    //更新対象オブジェクトの抽出
+    if(detailMutateKey){
+      const showCache = cache.get(detailMutateKey) as { projects: EnrichedProject[] } | undefined;
+      showTargetProjects = showCache?.projects?.[0];
+    }
+    targetProject = isShowMode && showTargetProjects
+      ? showTargetProjects
+      : result?.project;
+
 
     console.log("projectId: " + projectId);
-    console.log("mutateKey",mutateKey);
+    console.log("showMutateKey",detailMutateKey);
+    console.log("indexMutateKey",listMutateKey);
     console.log("projectIndex",projectIndex);
 
     console.log("処理前の対象", targetProject);
 
-    if (!isShowMode && (!mutateKey || projectIndex === undefined)) {  //一覧ページに一度アクセスしているのに、キャッシュがない状態
-      console.error("キャッシュキーが存在せず、Indexを抽出できませんでした");
+    // キャッシュ異常時ハンドル
+    if (!isShowMode && (!listMutateKey || projectIndex === undefined)) {  //一覧ページに一度アクセスしているのに、キャッシュがない異常状態
+      console.error("Indexキャッシュキーが存在異常終了しました");
+      return;
+    } else if(isShowMode && (!detailMutateKey || projectIndex === undefined)){
+      console.error("Showキャッシュキーが存在せず異常終了しました");
       return;
     }
   };
 
-  // レスポンス適用処理(データ整合性確保)
+   // レスポンス適用処理(データ整合性確保)
   const createFinalizeProjects = (res: any, updatedProject: EnrichedProject) => {
     const realBookmarkId = Number(res.id);
     const finalizedProject = createUpdatedProject(updatedProject, true, realBookmarkId);
@@ -151,8 +96,8 @@ export const useBookmarkToggle = (
 
 
   // ブックマーク追加関数
-  const handleBookmark = async (projectId: string) => {
-    initialize(projectId);
+  const handleBookmark = async (projectId: string, mode:"list" | "detail") => {
+    initialize(projectId, mode);
     const isBookmarkMode = true;
 
     if (!targetProject) {
@@ -163,56 +108,34 @@ export const useBookmarkToggle = (
     const updatedProject = createUpdatedProject(targetProject, true, Math.random());
     console.log("updatedProject:",updatedProject);
 
-    //更新処理関係
-    if (isShowMode){
-      applyShowProject(updatedProject, mutateKey, projectIndex, isShowMode, projectId, isBookmarkMode);
-      const res = await bookmarkProject(projectId);
-      const finalizedProject = createFinalizeProjects(res, updatedProject);
-      if (setProjects) {
-        setProjects([finalizedProject]);
-      }
-
-    } else {
-
-      if (!mutateKey || projectIndex === undefined) { //projectIndexが0のケースではfalsyとなる為、文字列とは区別
-        console.error("キャッシュが初期化されていません");
-        return;
-      }
-
-      if (projects){ //isShowModeではない詳細ページの場合
-        await applyShowProject(updatedProject, mutateKey, projectIndex, isShowMode, projectId, isBookmarkMode);
-        // 更新後のキャッシュから最新のbookmarkIdを取得
-        updateShowProjectFromCache(updatedProject, mutateKey, projectIndex, setProjects);
-
-      }else{ //一覧ページの場合
-        const createApiRequest = isBookmarkMode ? bookmarkProject : undefined;
-        const destroyApiRequest = !isBookmarkMode ? unBookmarkProject : undefined;
-        const finalizeData = isBookmarkMode ? createFinalizeProjects : destroyFinalizeProjects;
-        applyMutate({
-          updatedProject,
-          mutateKey,
-          projectIndex,
-          projectId,
-          createApiRequest,
-          destroyApiRequest,
-          finalizeData
-        });
-      }
-    }
-    console.log("追加の楽観的更新後", projects, cache);
+    // 更新処理
+    const createApiRequest = isBookmarkMode ? bookmarkProject : undefined;
+    const destroyApiRequest = !isBookmarkMode ? unBookmarkProject : undefined;
+    const finalizeData = isBookmarkMode ? createFinalizeProjects : destroyFinalizeProjects;
+    applyMutate({
+      updatedProject,
+      detailMutateKey,
+      listMutateKey,
+      projectIndex,
+      projectId,
+      createApiRequest,
+      destroyApiRequest,
+      finalizeData,
+      isShowMode,
+    });
+    console.log("追加の楽観的更新後", cache);
   };
 
 
 
   // ブックマーク解除関数
-  const handleUnBookmark = async (projectId: string, bookmarkId: number | null) => {
-    if( !bookmarkId ){
+  const handleUnBookmark = async (projectId: string, bookmarkId: number | null, mode: "list" | "detail") => {
+    if(!bookmarkId ){
       console.error("不正なブックマークIDを検知しました");
       return;
     }
 
-    initialize(projectId);
-
+    initialize(projectId, mode);
     const isBookmarkMode = false;
 
     if (!targetProject) {
@@ -222,40 +145,20 @@ export const useBookmarkToggle = (
     const updatedProject = createUpdatedProject(targetProject, false, null);
     console.log("updatedProject", updatedProject);
 
-    if (isShowMode){
-      applyShowProject(updatedProject, mutateKey, projectIndex, isShowMode, projectId, isBookmarkMode, bookmarkId.toString());
-      const res = await unBookmarkProject(projectId, bookmarkId.toString());
-      const finalizedProject = destroyFinalizeProjects(res, updatedProject);
-      if (setProjects) {
-        setProjects([finalizedProject]);
-      }
-    } else{
-
-      if (!mutateKey || projectIndex === undefined) { //projectIndexが0のケースではfalsyとなる為、文字列とは区別
-        console.error("キャッシュが初期化されていません");
-        return;
-      }
-
-      if (projects){ //isShowModeではない詳細ページの場合
-        await applyShowProject(updatedProject, mutateKey, projectIndex, isShowMode, projectId, isBookmarkMode, bookmarkId.toString());
-        // 更新後のキャッシュから最新のbookmarkIdを取得
-        updateShowProjectFromCache(updatedProject, mutateKey, projectIndex, setProjects);
-
-      }else{
-        const createApiRequest = isBookmarkMode ? bookmarkProject : undefined;
-        const destroyApiRequest = !isBookmarkMode ? unBookmarkProject : undefined;
-        applyMutate({
-          updatedProject,
-          mutateKey,
-          projectIndex,
-          projectId,
-          createApiRequest,
-          destroyApiRequest,
-          relatedId: bookmarkId.toString()
-        });
-      }
-    }
-    console.log("解除の楽観的更新後", projects, cache);
+    const createApiRequest = isBookmarkMode ? bookmarkProject : undefined;
+    const destroyApiRequest = !isBookmarkMode ? unBookmarkProject : undefined;
+    applyMutate({
+      updatedProject,
+      detailMutateKey,
+      listMutateKey,
+      projectIndex,
+      projectId,
+      createApiRequest,
+      destroyApiRequest,
+      relatedId: bookmarkId.toString(),
+      isShowMode,
+    });
+    console.log("解除の楽観的更新後",cache);
   };
 
   return { handleBookmark, handleUnBookmark };

--- a/front/src/utils/useApplyMutate.ts
+++ b/front/src/utils/useApplyMutate.ts
@@ -3,18 +3,20 @@ import { EnrichedProject } from "@sharedTypes/types";
 
 interface ApplyMutateProps {
   updatedProject: EnrichedProject;
-  mutateKey: string; //対象のリソースがどのページネーションページに存在するかを保持
-  projectIndex: number; //対象のリソースがprojects内のどの位置にあるかを保持
+  detailMutateKey?: string; //ShowページベースSWR
+  listMutateKey?: string; //IndexページベースSWR
+  projectIndex?: number; //対象のリソースがprojects内のどの位置にあるかを保持（詳細ページは0）
   projectId: string;
   createApiRequest?:((projectId: string) => Promise<any>) //新規処理専用
   destroyApiRequest?: ((projectId: string, relatedId: string) => Promise<any>); //削除処理専用
   finalizeData?: (response: any, project: EnrichedProject) => EnrichedProject; //リクエスト完了時の適用処理
   relatedId?: string; //削除リクエストに使用
+  isShowMode: boolean;
 }
 
 interface PageData {
   projects: EnrichedProject[];
-  meta: { total_pages: number; [key: string]: any };
+  meta?: { total_pages: number; [key: string]: any }; //Showの場合はなし
 }
 
 export const useApplyMutate = () => {
@@ -22,74 +24,144 @@ export const useApplyMutate = () => {
 
   const applyMutate = async ({
     updatedProject,
-    mutateKey,
-    projectIndex,
+    detailMutateKey, //オプション
+    listMutateKey, //オプション
+    projectIndex, //オプション
     projectId,
     createApiRequest, //オプション
     destroyApiRequest, //オプション
     finalizeData, //オプション
     relatedId, //オプション
+    isShowMode,
   }: ApplyMutateProps) => {
+
+    console.log("=== applyMutate 呼び出し ===");
+    console.log("updatedProject:", updatedProject);
+    console.log("detailMutateKey:", detailMutateKey);
+    console.log("listMutateKey:", listMutateKey);
+    console.log("projectIndex:", projectIndex);
+    console.log("projectId:", projectId);
+    console.log("createApiRequest:", createApiRequest ? "関数がセットされています" : "未定義");
+    console.log("destroyApiRequest:", destroyApiRequest ? "関数がセットされています" : "未定義");
+    console.log("finalizeData:", finalizeData ? "関数がセットされています" : "未定義");
+    console.log("relatedId:", relatedId);
+    console.log("isShowMode:", isShowMode);
+    console.log("===========================");
+
     try{
-      // マスターキー
-      const masterKey = "$inf$/api/projects?page=1"; //他のfetcherにも対応できるよう将来的に動的にすべき
-      // mutate(1.対象キー, 2. Updater関数, 3. オプション)
-      await mutate(
-        mutateKey,
-        async (currentData: PageData | undefined): Promise<PageData> => {
-          // ==========================
-          // 2. Updater関数: キャッシュ更新処理
-          // ==========================
-          if (!currentData) throw new Error("現在のデータが存在しません")
+      // どちらのページも開かれていない場合は異常であり処理を離脱
+      if (!detailMutateKey && !listMutateKey) {
+        console.warn("一覧ページ、詳細ページのどちらのキャッシュも存在しないため、更新処理をスキップしました。");
+        return;
+      }
 
-          // サーバーリクエスト
-          let response;
+      //Mutate処理
+      const updateCache = async (mutateKey: string | undefined, projectIndex: number | undefined ) => {
+        console.log("updateCache発動", mutateKey,projectIndex);
+        console.log("一覧ページのキャッシュ更新前", cache.get(indexMasterKey));
+        if (!mutateKey || projectIndex === undefined) return;
+        await mutate( //キャッシュ更新処理
+          mutateKey,
+          async (currentData: PageData | undefined): Promise<PageData> => {
+            // mutate(1.対象キー, 2. Updater関数, 3. オプション)
+            console.log("mutate関数発動", mutateKey,currentData);
 
-          console.log("リクエスト前", destroyApiRequest, createApiRequest, relatedId);
+            if (!currentData) throw new Error("現在のデータが存在しません")
 
-          if (destroyApiRequest && relatedId) {
-            // destroy関連のAPIリクエスト（relatedIdが必須）
-            response = await destroyApiRequest(projectId, relatedId);
-          } else if (createApiRequest) {
-            // create関連のAPIリクエスト（relatedIdが不要）
-            response = await createApiRequest(projectId);
-          }else {
-            throw new Error("APIリクエスト関数が指定されていません");
-          }
+            // サーバーリクエスト（create/delete双方に対応）
+            let response;
+            if (destroyApiRequest && relatedId) {
+              console.log("削除リクエスト開始", destroyApiRequest, relatedId);
+              // destroy関連のAPIリクエスト（relatedIdが必須）
+              response = await destroyApiRequest(projectId, relatedId);
+            } else if (createApiRequest) {
+              console.log("新規リクエスト開始", createApiRequest);
+              // create関連のAPIリクエスト（relatedIdが不要）
+              response = await createApiRequest(projectId);
+            }else {
+              throw new Error("APIリクエスト関数が指定されていません");
+            }
 
-          // レスポンスを元に更新されたプロジェクトデータを生成（finalize処理が必要なものは関数実行）
-          const finalizedProject = finalizeData
-            ? finalizeData(response, updatedProject)
-            : updatedProject;
+            // レスポンスを元に更新されたプロジェクトデータを生成（finalize処理が必要なものは関数実行）
+            console.log("終了データを保持", response, finalizeData);
+            const finalizedProject = finalizeData
+              ? finalizeData(response, updatedProject)
+              : updatedProject;
 
-          // 更新処理
-          const updatedProjects = [...currentData.projects];
-          updatedProjects[projectIndex] = finalizedProject;
+            // 一覧ページのキャッシュも更新
+            if(isShowMode && listMutateKey){
+              console.log("詳細更新後、一覧も更新");
+              await mutate(
+                indexMasterKey,
+                (prevData: PageData[] | undefined) => {
+                  if (!prevData) return prevData;
+                  return prevData.map((page) => ({
+                    ...page,
+                    projects: page.projects.map((p) => (p.id === finalizedProject.id ? finalizedProject : p)),
+                  }));
+                },
+                { revalidate: false } // ここでリクエストを発生させない
+              );
+            } else if( !isShowMode && detailMutateKey){
+              await mutate(
+                detailMutateKey,
+                (prevData: PageData | undefined) => {
+                if (!prevData) return prevData;
+                return {
+                  ...prevData,
+                  projects: prevData.projects.map((p) => (p.id === finalizedProject.id ? finalizedProject : p)),
+                };
+              }, { revalidate: false });
+            };
 
-          return { ...currentData, projects: updatedProjects };
-        },
-        {
-          // ==========================
-          // 3. オプション: (リクエスト終了前の)楽覴的更新処理
-          // ==========================
-          optimisticData: (prevData: PageData | undefined): PageData=> {
-            if (!prevData) throw new Error("楽観的更新用のデータが存在しません");
-
-            const optimisticProjects = [...prevData.projects];
-            optimisticProjects[projectIndex] = updatedProject;
-
-            return { ...prevData, projects: optimisticProjects };
+            return { ...currentData, projects: [finalizedProject] };
           },
-          populateCache: true, // キャッシュ保存(デフォルトはtrue)
-          rollbackOnError: true, // リクエストエラー時の自動ロールバック
-          revalidate: false, // 更新後の再フェッチを防ぐ
+          {
+            optimisticData: (prevData: PageData | undefined): PageData=> { //楽観的更新
+              if (!prevData) throw new Error("楽観的更新用のデータが存在しません");
+              console.log("楽観的更新発動",prevData)
+
+              const optimisticProjects = [...prevData.projects];
+              optimisticProjects[projectIndex] = updatedProject;
+              console.log("更新後データ", optimisticProjects)
+
+              return { ...prevData, projects: optimisticProjects };
+            },
+            // populateCache: false, // キャッシュ保存(デフォルトはtrue)
+            rollbackOnError: true, // リクエストエラー時の自動ロールバック
+            revalidate: false, // 更新後の再フェッチを防ぐ
+          }
+        );
+      }
+
+      // マスターキー定義（SWRInfinityを使用しないShow側はshowMutateKeyがマスターキーとなる）
+      const indexMasterKey = "$inf$/api/projects?page=1";
+
+      //Showページ処理の場合
+      if (isShowMode) {
+        console.log("Show時の処理開始")
+        if (detailMutateKey) {
+          console.log("詳細処理");
+          await updateCache(detailMutateKey, 0); //Showの楽観的更新
+          console.log("一覧ページのキャッシュ更新後", cache.get(indexMasterKey));
         }
-      );
-      // マスターキーにmutateを使いUIの再レンダリングをトリガー
-      await mutate(masterKey);
-    } catch (error) {
-      console.error("キャッシュ更新中にエラーが発生しました:", error);
-    }
-  };
+        if (listMutateKey) {
+          console.log("一覧処理");
+          await mutate(indexMasterKey);
+        }
+      //Indexページ処理の場合
+      } else {
+        console.log("Index時の処理開始")
+        if (listMutateKey) {
+          console.log("一覧処理");
+          await updateCache(listMutateKey, projectIndex); //Indexの楽観的更新
+          await mutate(indexMasterKey);
+        }
+      }
+
+      } catch (error) {
+        console.error("キャッシュ更新中にエラーが発生しました:", error);
+      }
+    };
   return applyMutate;
 };

--- a/front/src/utils/useFindPageKeyAndIndexByProjectId.ts
+++ b/front/src/utils/useFindPageKeyAndIndexByProjectId.ts
@@ -1,11 +1,11 @@
 import { useSWRConfig } from "swr";
 import { EnrichedProject, PageKeyResult } from "@sharedTypes/types";
 
-// SWRのキャッシュから特定のプロジェクトIDを持つページキーを探すカスタムフック
+// SWRの一覧キャッシュから特定のプロジェクトIDを持つページキーを探すカスタムフック
 export const useFindPageKeyByProjectId = () => {
   const { cache } = useSWRConfig();
 
-  const findPageKeyByProjectId = (projectId: string): PageKeyResult => {
+  const findPageKeyByProjectId = (projectId: string): PageKeyResult | undefined => {
     // キーを基準に巡回
     for (const key of cache.keys()) {
       // ページネーションのキーかどうか確認
@@ -23,7 +23,7 @@ export const useFindPageKeyByProjectId = () => {
         }
       }
     }
-    throw new Error(`プロジェクトID ${projectId} に対応するキャッシュが見つかりませんでした。`);
+    return undefined;
   };
 
   return findPageKeyByProjectId;


### PR DESCRIPTION
### Tasks
- [ ] 詳細ページをSWR管理下に置く
- [ ] 楽観的更新処理のロジック変更
- [ ] 投稿に対する各アクションへの適用

### 留意点
- [ ] 詳細、一覧の連携処理の際に一部楽観的更新が行えていない部分があり今後改善が必要。単体では行えているが、特にSWRInfinityを使用している投稿一覧への外部からの更新適用処理が非常に特殊であり、深い調査が必要
- [ ] 一覧での削除の際の再フェッチで存在しない詳細ページへの遷移が起こり原因不明、今回はrouter.replaceにて対応
- [ ] いいね、およびブックマークの楽観的処理の共通処理化を行っておらず冗長である
- [ ] 楽観的処理の際、リクエストのレスポンスを待たずに再フェッチが行われている状況
- [ ] 一覧ページにおける編集完了時に、スクロール位置を保持できない問題に未対応

close #154 
