### PR TITLE
Issue163 notification

### DIFF
--- a/back/app/controllers/api/v1/collaboration_managements_controller.rb
+++ b/back/app/controllers/api/v1/collaboration_managements_controller.rb
@@ -52,6 +52,14 @@ class Api::V1::CollaborationManagementsController < ApplicationController
       unless collaboration.update(status: :approved)
         raise ActiveRecord::Rollback, "Collaboration ID #{collaboration.id} のステータス更新に失敗しました: #{collaboration.errors.full_messages.join(', ')}"
       end
+
+      # 通知
+      Notification.create!(
+      recipient: collaboration.user,
+      sender: project.user,
+      notifiable: collaboration,
+      notification_type: :collaboration_approved
+    )
     end
   end
 

--- a/back/app/controllers/api/v1/notifications_controller.rb
+++ b/back/app/controllers/api/v1/notifications_controller.rb
@@ -1,0 +1,102 @@
+class Api::V1::NotificationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    notifications = current_user.received_notifications
+                                .includes(:sender, notifiable: [:user, project: :user, commentable: :user])
+                                .order(created_at: :desc)
+                                .limit(50)
+
+    #このエンドポイントにアクセスした時点で既読したと言う扱いにし、未読を既読に変更、Redisから一時データを削除
+    unread_notifications = notifications.unread
+    unread_notifications.update_all(read: true) if unread_notifications.exists?
+    # Redis.current.del("user:#{current_user.id}:has_unread_notifications")
+
+    render json: notifications.map { |notification| format_notification(notification) }
+  end
+
+  # ログイン状態での初回アプリアクセス時の通知有無の確認の為のエンドポイント
+  def has_unread
+    has_unread = current_user.received_notifications.unread.exists?
+    render json: { has_unread: has_unread }
+  end
+
+  private
+
+  def format_notification(notification)
+    {
+      id: notification.id,
+      notification_type: notification.notification_type,
+      read: notification.read,
+      created_at: notification.created_at,
+      recipient: format_user(notification.recipient),
+      sender: notification.sender ? format_user(notification.sender) : nil,
+      notifiable: format_notifiable(notification),
+      message: generate_message(notification)
+    }
+  end
+
+
+  def format_user(user)
+    return nil unless user
+    {
+      id: user.id,
+      nickname: user.nickname,
+      username: user.username,
+      avatar_url: user.avatar_url
+    }
+  end
+
+  def format_notifiable(notification)
+    case notification.notifiable
+    when Project
+      {
+        id: notification.notifiable.id,
+        project_id: notification.notifiable.id,
+        project_title: notification.notifiable.title
+      }
+    when Comment
+      project = find_project_from_comment(notification.notifiable)
+      {
+        id: notification.notifiable.id,
+        project_id: project&.id,
+        project_title: project&.title
+      }
+    when Collaboration
+      {
+        id: notification.notifiable.id,
+        project_id: notification.notifiable.project.id,
+        project_title: notification.notifiable.project.title
+      }
+    else
+      { id: notification.notifiable.id }
+    end
+  end
+
+  def find_project_from_comment(comment)
+    return comment.commentable if comment.commentable.is_a?(Project)
+
+    while comment.commentable.is_a?(Comment)
+      comment = comment.commentable
+    end
+
+    comment.commentable if comment.commentable.is_a?(Project)
+  end
+
+
+  def generate_message(notification)
+    sender_name = notification.sender&.nickname || notification.sender&.username || "名無しのユーザー"
+    case notification.notification_type
+    when "like"
+      "#{sender_name} さんがあなたの投稿に「いいね！」しました"
+    when "comment"
+      "#{sender_name} さんがあなたの投稿にコメントしました"
+    when "collaboration_request"
+      "#{sender_name} さんがあなたの投稿に応募しました"
+    when "collaboration_approved"
+      "#{sender_name} さんの投稿への応募が承認されました"
+    else
+      "新しい通知があります"
+    end
+  end
+end

--- a/back/app/models/collaboration.rb
+++ b/back/app/models/collaboration.rb
@@ -2,10 +2,26 @@ class Collaboration < ApplicationRecord
   belongs_to :user
   belongs_to :project
   has_one :audio_file, as: :fileable, dependent: :destroy
+  has_one :notification, as: :notifiable, dependent: :destroy
 
   enum status: { pending: 0, approved: 1, rejected: 2}
 
   validates :comment, length: { maximum: 255 }, allow_nil: true
   # statusの値保証
   validates :status, inclusion: { in: statuses.keys }
+
+  after_create :create_notification
+
+  private
+
+  def create_notification
+    return if user == project.user
+
+    Notification.create!(
+      recipient: project.user,
+      sender: user,
+      notifiable: self,
+      notification_type: :collaboration_request
+    )
+  end
 end

--- a/back/app/models/comment.rb
+++ b/back/app/models/comment.rb
@@ -2,9 +2,25 @@ class Comment < ApplicationRecord
   has_ancestry counter_cache: true
   belongs_to :user
   belongs_to :commentable, polymorphic: true
+  has_one :notification, as: :notifiable, dependent: :destroy
 
   validates :user_id, presence: true
   validates :commentable_id, presence: true
   validates :commentable_type, presence: true, inclusion: { in: %w[Project Comment]}
   validates :content, presence: true, length: { minimum: 1, maximum: 255 }
+
+  after_create :create_notification
+
+  private
+
+  def create_notification
+    return if user == commentable.user
+
+    Notification.create!(
+      recipient: commentable.user,
+      sender: self.user,
+      notifiable: self,
+      notification_type: :comment
+    )
+  end
 end

--- a/back/app/models/like.rb
+++ b/back/app/models/like.rb
@@ -1,8 +1,31 @@
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :likeable, polymorphic: true
+  has_one :notification, as: :notifiable, dependent: :destroy
 
   validates :user_id, presence: true, uniqueness: {scope: [:likeable_type, :likeable_id], message: "いいねは一度しかできません"}
   validates :likeable_type, presence: true, inclusion: {in: %w[Project Comment]}
   validates :likeable_id, presence: true
+
+  after_create :create_notification
+
+  private
+
+  def create_notification
+    return if user == likeable.user
+
+    unless Notification.exists?(
+      recipient: likeable.user,
+      sender: user,
+      notifiable: likeable,
+      notification_type: :like
+    )
+      Notification.create!(
+        recipient: likeable.user,
+        sender: user,
+        notifiable: likeable,
+        notification_type: :like
+      )
+    end
+  end
 end

--- a/back/app/models/notification.rb
+++ b/back/app/models/notification.rb
@@ -1,0 +1,25 @@
+class Notification < ApplicationRecord
+  belongs_to :recipient, class_name: "User"
+  belongs_to :sender, class_name: "User", optional: true #システム通知にも対応させる為オプショナル有効
+  belongs_to :notifiable, polymorphic: true, optional: true
+
+  enum notification_type: {
+    like: 0,
+    comment: 1,
+    collaboration_request: 2,
+    collaboration_approved: 3
+  }
+
+  validates :notification_type, presence: true, inclusion: { in: notification_types.keys}
+  validates :expires_at, presence: true
+
+  scope :unread, -> {where(read: false)}
+
+  before_validation :set_expiration, on: :create
+
+  private
+
+  def set_expiration
+    self.expires_at ||= 180.days.from_now
+  end
+end

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -5,6 +5,7 @@ class Project < ApplicationRecord
   has_many :likes, as: :likeable, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
   has_many :comments, as: :commentable, dependent: :destroy
+  has_many :notifications, as: :notifiable, dependent: :destroy
 
   enum status: { open: 0, draft: 1, closed: 2}
   enum visibility: { is_public: 0, is_private: 1 }

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ActiveRecord::Base
   has_many :likes, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :received_notifications, class_name: "Notification", foreign_key: "recipient_id", dependent: :destroy
+  has_many :sent_notifications, class_name: "Notification", foreign_key: "sender_id", dependent: :nullify
 
   validates :username,
           uniqueness: { message: "は既に使用されています" },

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -28,6 +28,11 @@ Rails.application.routes.draw do
         resources :user_profiles, only: %i[show]
         resources :other_users, only: [:index]
       end
+      resources :notifications, only: %i[index] do
+        collection do
+          get :has_unread
+        end
+      end
     end
   end
 end

--- a/back/db/migrate/20250212002736_create_notifications.rb
+++ b/back/db/migrate/20250212002736_create_notifications.rb
@@ -1,0 +1,14 @@
+class CreateNotifications < ActiveRecord::Migration[7.0]
+  def change
+    create_table :notifications do |t|
+      t.references :recipient, null: false, foreign_key: { to_table: :users }
+      t.references :sender, foreign_key: { to_table: :users }
+      t.references :notifiable, polymorphic: true, null: true
+      t.integer :notification_type, null: false, default: 0
+      t.boolean :read, default: false, null: false
+      t.datetime :expires_at, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_10_145507) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_12_002736) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -68,6 +68,21 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_10_145507) do
     t.index ["user_id", "likeable_type", "likeable_id"], name: "index_likes_on_user_id_and_likeable_type_and_likeable_id", unique: true
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "recipient_id", null: false
+    t.bigint "sender_id"
+    t.string "notifiable_type"
+    t.bigint "notifiable_id"
+    t.integer "notification_type", default: 0, null: false
+    t.boolean "read", default: false, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable"
+    t.index ["recipient_id"], name: "index_notifications_on_recipient_id"
+    t.index ["sender_id"], name: "index_notifications_on_sender_id"
+  end
+
   create_table "projects", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "title", null: false
@@ -113,5 +128,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_10_145507) do
   add_foreign_key "collaborations", "users"
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "users"
+  add_foreign_key "notifications", "users", column: "recipient_id"
+  add_foreign_key "notifications", "users", column: "sender_id"
   add_foreign_key "projects", "users"
 end

--- a/back/test/controllers/api/v1/notifications_controller_test.rb
+++ b/back/test/controllers/api/v1/notifications_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::NotificationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/back/test/fixtures/notifications.yml
+++ b/back/test/fixtures/notifications.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  recipient_id: 
+  sender_id: 
+  project_id: 
+  notification_type: MyString
+  read: false
+  expires_at: 2025-02-12 09:27:36
+
+two:
+  recipient_id: 
+  sender_id: 
+  project_id: 
+  notification_type: MyString
+  read: false
+  expires_at: 2025-02-12 09:27:36

--- a/back/test/models/notification_test.rb
+++ b/back/test/models/notification_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/front/src/app/api/notifications/route.ts
+++ b/front/src/app/api/notifications/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  try {
+    const response = await fetch(`${process.env.BACKEND_API_URL}/api/v1/notifications`, {
+      method: "GET",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: req.headers.get("cookie") || "",
+      },
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return NextResponse.json({ error: "通知の取得に失敗しました" }, { status: response.status });
+    }
+
+    const notifications = await response.json();
+    console.log("通知レスポンス ", notifications);
+    return NextResponse.json(notifications);
+  } catch (error) {
+    console.error("通知取得エラー:", error);
+    return NextResponse.json({ error: "サーバーエラー" }, { status: 500 });
+  }
+}

--- a/front/src/app/api/projects/[projectId]/route.ts
+++ b/front/src/app/api/projects/[projectId]/route.ts
@@ -5,7 +5,7 @@ import { createInitialProjectData } from "@utils/createInitialProjectData";
 export async function GET(req: NextRequest, context : { params: Promise<Record<string, string>>}) {
   const resolvedParams = await context.params;
   const projectId = resolvedParams.projectId;
-  console.log("projectId: " + projectId);
+  // console.log("projectId: " + projectId);
 
   try {
     const response = await fetch(`${process.env.BACKEND_API_URL}/api/v1/projects/${projectId}`, {

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { ProjectProvider } from "@context/useProjectContext";
 import { CurrentRouteProvider } from "@context/useCurrentRouteContext"
 import { ClientCacheProvider } from "@context/useClientCacheContext";
 import { FeedbackProvider } from "@context/useFeedbackContext";
+import { NotificationProvider } from "@context/useNotificationContext";
 
 import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
@@ -58,16 +59,18 @@ export default function RootLayout({ children }: Readonly<{
             >
           <FeedbackProvider>
             <AuthProvider>
-              <CurrentRouteProvider>
-                <ClientCacheProvider >
-                  <ProjectProvider>
-                    <ThemeProviderWrapper>
-                      <AuthModal />
-                      {children}
-                    </ThemeProviderWrapper>
-                  </ProjectProvider>
-                </ClientCacheProvider>
-              </CurrentRouteProvider>
+              <NotificationProvider>
+                <CurrentRouteProvider>
+                  <ClientCacheProvider >
+                    <ProjectProvider>
+                      <ThemeProviderWrapper>
+                        <AuthModal />
+                        {children}
+                      </ThemeProviderWrapper>
+                    </ProjectProvider>
+                  </ClientCacheProvider>
+                </CurrentRouteProvider>
+              </NotificationProvider>
             </AuthProvider>
           </FeedbackProvider>
         </SWRConfig>

--- a/front/src/app/notification/page.tsx
+++ b/front/src/app/notification/page.tsx
@@ -1,6 +1,7 @@
 import { Header } from "@components/Header";
 import { FeedbackAlert } from "@components/FeedbackAlert";
 import { BottomNavi } from "@components/BottomNavi";
+import { NotificationListWrapper } from "@Notification/NotificationListWrapper";
 import { Suspense } from"react";
 
 export default function Notification(){
@@ -9,8 +10,7 @@ export default function Notification(){
       <div>
         <Header />
         <FeedbackAlert />
-        <h1>通知画面</h1>
-        <h3>本リリースまでお待ちください...</h3>
+        <NotificationListWrapper />
         <BottomNavi />
       </div>
     </Suspense>

--- a/front/src/components/BottomNavi.tsx
+++ b/front/src/components/BottomNavi.tsx
@@ -3,17 +3,20 @@
 import { useEffect } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { useCurrentRouteState} from "@context/useCurrentRouteContext";
+import { useNotificationContext } from "@context/useNotificationContext";
 import BottomNavigation from "@mui/material/BottomNavigation";
 import BottomNavigationAction from "@mui/material/BottomNavigationAction";
 import HomeIcon from "@mui/icons-material/Home";
 import AddIcon from "@mui/icons-material/Add";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import PersonIcon from "@mui/icons-material/Person";
+import Badge from "@mui/material/Badge";
 
 export function BottomNavi() {
   const pathname = usePathname();
   const router = useRouter();
   const { currentRoute, setCurrentRoute } = useCurrentRouteState();
+  const { hasUnread } = useNotificationContext();
 
   // `router.pathname` が変更されたら `currentRoute` を更新
   useEffect(() => {
@@ -86,13 +89,19 @@ export function BottomNavi() {
             color: "secondary.main",
           },
         }}/>
-      <BottomNavigationAction icon={<NotificationsIcon />}
+      <BottomNavigationAction
+        icon={
+          <Badge color="error" variant="dot" invisible={!hasUnread}>
+            <NotificationsIcon />
+          </Badge>
+        }
         sx={{
           color: "primary.contrastText",
           "&.Mui-selected": {
             color: "secondary.main",
           },
-        }}/>
+        }}
+      />
       <BottomNavigationAction icon={<PersonIcon />}
         sx={{
           color: "primary.contrastText",

--- a/front/src/components/Notification/NotificationList.tsx
+++ b/front/src/components/Notification/NotificationList.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { Notification } from "@sharedTypes/types";
+import { Box, Avatar, Typography, Divider, ButtonBase } from "@mui/material";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import { formatDistanceToNow } from "date-fns";
+import { ja } from "date-fns/locale";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  notification: Notification;
+}
+
+export const NotificationList = ({ notification }: Props) => {
+  const router = useRouter();
+
+  const handleNotificationClick = () => {
+    router.push(`/projects/${notification.notifiable.project_id}/project_show`);
+  };
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: 2,
+          cursor: "pointer",
+        }}
+        onClick={handleNotificationClick}
+      >
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <ButtonBase
+            sx={{
+              borderRadius: "50%",
+              overflow: "hidden",
+              transition: "transform 0.2s ease-in-out",
+              "&:active": { transform: "scale(0.8)" },
+            }}
+          >
+            <Avatar src={notification.sender?.avatar_url || "/default-icon.png"} />
+          </ButtonBase>
+          <Box sx={{ ml: 2 }}>
+            <Typography variant="body1">{notification.message}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              {formatDistanceToNow(new Date(notification.created_at), { addSuffix: true, locale: ja })}「{notification.notifiable.project_title}」
+            </Typography>
+          </Box>
+        </Box>
+        <ChevronRightIcon color="action" />
+      </Box>
+      <Divider />
+    </>
+  );
+};

--- a/front/src/components/Notification/NotificationListWrapper.tsx
+++ b/front/src/components/Notification/NotificationListWrapper.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Box, CircularProgress, Typography, Alert } from "@mui/material";
+import { NotificationList } from "@Notification/NotificationList";
+import { useNotifications } from "@swr/useNotificationsSWR";
+
+
+export const NotificationListWrapper = () => {
+  const { notifications, isLoading, isValidating, isError } = useNotifications();
+  console.log("notifications", notifications);
+
+  if (isError) {
+    return (
+      <Box sx={{ mx: 2, my: 4 }}>
+        <Alert severity="error">通知の取得に失敗しました。</Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ pb: "56px" }}>
+      {isValidating || isLoading ? (
+        <Box sx={{ textAlign: "center", py: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : notifications.length === 0 ? (
+        <Box sx={{ textAlign: "center", my: 4 }}>
+          <Typography variant="h6" color="textSecondary">
+            通知はありません。
+          </Typography>
+        </Box>
+      ) : (
+        <Box>
+          {notifications.map((notification) => (
+            <NotificationList key={notification.id} notification={notification} />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/front/src/components/Project/ProjectCard.tsx
+++ b/front/src/components/Project/ProjectCard.tsx
@@ -76,7 +76,7 @@ export function ProjectCard({
   const { deleteProject } = useDeleteProjectRequest();
 
     // SWR関連
-  const { revalidateAllLists } = useApplyMutate();
+  // const { revalidateAllLists } = useApplyMutate();
   const { mutate: indexMutate } = useProjectList(); //一覧
   const { mutate: globalMutate } = useSWRConfig()
   const detailMutateKey = `/api/projects/${project.id}`;
@@ -237,7 +237,7 @@ export function ProjectCard({
       setIsEditing(false);
       globalMutate(detailMutateKey);
       if (category){
-        revalidateAllLists();
+        // revalidateAllLists();
       }
       setFeedbackByKey("project:edit:success");
     }catch(error: any) {
@@ -268,7 +268,7 @@ export function ProjectCard({
   //削除ボタン
   const handleDeleteProject = async () =>{
     await deleteProject(project.id)
-    revalidateAllLists();
+    // revalidateAllLists();
     const fromPage = searchParams.get("from");
     if (fromPage === "my_projects" || fromPage === "collaborating" || fromPage === "collaborated" || fromPage === "bookmarks") {
       router.replace(`/mypage?tab=${fromPage}&feedback=project:delete:success`);
@@ -276,7 +276,7 @@ export function ProjectCard({
       router.replace("/projects?feedback=project:delete:success");
     } else if (mode === "list"){ //一覧系ページにて削除処理
       setFeedbackByKey("project:delete:success");
-      revalidateAllLists();
+      // revalidateAllLists();
     } else{ //詳細ページにリンクアクセスしている場合
       router.replace("/projects?feedback=project:delete:success");
     }

--- a/front/src/components/Project/ProjectShowWrapper.tsx
+++ b/front/src/components/Project/ProjectShowWrapper.tsx
@@ -23,7 +23,8 @@ export function ProjectShowWrapper(){
     projects,
     isLoading: isProjectLoading,
     isError: isProjectError,
-    mutate: mutateProject
+    mutate: mutateProject,
+    isValidating : isShowValidating,
   } = useShowProject(projectId);
   console.log("useShowProjectが取得したキャッシュ", projects);
 
@@ -101,7 +102,7 @@ export function ProjectShowWrapper(){
 
   return(
     <Box sx={{ bottom: 112 }}>
-      {isValidating || isLoading ? (
+      {isValidating || isShowValidating || isLoading ? (
         <Box sx={{ textAlign: "center", py: 4 }}>
           <CircularProgress />
         </Box>

--- a/front/src/context/useNotificationContext.tsx
+++ b/front/src/context/useNotificationContext.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState, createContext, useContext, useEffect, useCallback } from "react";
+import axios from "axios";
+import { useAuthContext } from "@context/useAuthContext";
+
+
+interface NotificationContextType {
+  hasUnread: boolean;
+  refreshUnreadStatus: () => void;
+}
+
+const NotificationContext = createContext<NotificationContextType>({
+  hasUnread: false,
+  refreshUnreadStatus: () => {},
+});
+
+export const NotificationProvider = ({ children }: { children: React.ReactNode }) => {
+  const { signIn, isAuthenticated } = useAuthContext();
+  const [hasUnread, setHasUnread] = useState<boolean>(false);
+
+  // 未読状態の取得
+  const fetchUnreadStatus = useCallback(async () => {
+    if (!signIn()) return;
+
+    try {
+      const response = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/notifications/has_unread`, { withCredentials: true });
+      setHasUnread(response.data.has_unread);
+      console.log("未読状態:", response.data.hasUnread);
+    } catch (error) {
+      console.error("通知の未読状態の取得に失敗しました:", error);
+    }
+  }, [signIn]);
+
+  useEffect(() => {
+    fetchUnreadStatus();
+  }, [isAuthenticated]);
+
+  return (
+    <NotificationContext.Provider value={{
+      hasUnread,
+      refreshUnreadStatus: fetchUnreadStatus
+      }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+};
+
+export const useNotificationContext = () => useContext(NotificationContext);

--- a/front/src/hooks/swr/fetcher.ts
+++ b/front/src/hooks/swr/fetcher.ts
@@ -1,4 +1,4 @@
-import { EnrichedProject, InitialProjectData, InitialProjectResponse, Meta, PageData } from "@sharedTypes/types";
+import { EnrichedProject, InitialProjectData, InitialProjectResponse, Meta, PageData, Notification } from "@sharedTypes/types";
 import { applyIsOwnerToProjects } from "@utils/applyIsOwnerToProjects";
 
 
@@ -28,4 +28,15 @@ export const fetchProjectDetail = async (url: string): Promise<PageData> => {
     projects: enrichedProjects,
     meta: { total_pages: 1 }, // ダミーの `meta` を追加（一覧ページと統一）
   };
+};
+
+//通知用
+export const fetchNotifications = async (url: string): Promise<Notification[]> => {
+  const response = await fetch(url, { credentials: "include" });
+
+  if (!response.ok) {
+    throw new Error("通知データの取得に失敗しました");
+  }
+
+  return await response.json();
 };

--- a/front/src/hooks/swr/useNotificationsSWR.ts
+++ b/front/src/hooks/swr/useNotificationsSWR.ts
@@ -1,0 +1,26 @@
+"use client";
+import useSWR from "swr";
+import { fetchNotifications } from "@swr/fetcher";
+import { Notification } from "@sharedTypes/types";
+
+export function useNotifications() {
+  const { data, error, isLoading, isValidating, mutate } = useSWR<Notification[]>(
+    "/api/notifications",
+    fetchNotifications,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      revalidateOnMount: true,
+      fallbackData: []
+    }
+  );
+  console.log("SWR data:", data);
+
+  return {
+    notifications: data ?? [],
+    isLoading,
+    isValidating,
+    isError: !!error,
+    mutate,
+  };
+}

--- a/front/src/hooks/swr/useShowProjectSWR.ts
+++ b/front/src/hooks/swr/useShowProjectSWR.ts
@@ -4,7 +4,7 @@ import { PageData } from "@sharedTypes/types";
 import { fetchProjectDetail } from "@swr/fetcher";
 
 export function useShowProject(projectId: string) {
-  const { data, error, isLoading, mutate } = useSWR<PageData>(
+  const { data, error, isLoading, isValidating, mutate } = useSWR<PageData>(
     projectId ? `/api/projects/${projectId}` : null,
     fetchProjectDetail,
     {
@@ -22,6 +22,7 @@ export function useShowProject(projectId: string) {
     projects: data?.projects ?? [],
     isLoading,
     isError: !!error,
+    isValidating,
     mutate,
   };
 }

--- a/front/src/sharedTypes/types.ts
+++ b/front/src/sharedTypes/types.ts
@@ -122,6 +122,37 @@ export interface ExtendedCollaboration extends Collaboration {
   audioBuffer: AudioBuffer;
 }
 
+//Notifications型定義
+export interface UserSummary {
+  id: number;
+  nickname?: string;
+  username?: string;
+  avatar_url?: string;
+}
+
+export interface Notifiable {
+  id: number;
+  project_id?: number;
+  project_title?: string;
+}
+
+export interface Notification {
+  id: number;
+  notification_type: "like" | "comment" | "collaboration_request" | "collaboration_approved";
+  read: boolean;
+  created_at: string;
+  recipient: UserSummary;
+  sender?: UserSummary;
+  notifiable: Notifiable;
+  message: string;
+}
+
+export interface NotificationResponse {
+  notifications: Notification[];
+}
+
+
+
 // Included 型定義（Union 型で表現）
 export type IncludedItem = User | AudioFile | InitialComment;
 
@@ -147,7 +178,6 @@ export interface CollaborationManagementIndexResponse {
   data: Project[];
   included: IncludedItem[];
 }
-
 
 
 

--- a/front/src/utils/useApplyMutate.ts
+++ b/front/src/utils/useApplyMutate.ts
@@ -27,11 +27,11 @@ interface PageData {
 
 export const useApplyMutate = () => {
   const { mutate, cache } = useSWRConfig();
-  const { mutate: indexMutate } = useProjectList()
-  const { mutate: myMutate } = useMyProjects("my_projects")
-  const { mutate: myCollaboratingMutate } = useMyProjects("collaborating")
-  const { mutate: myCollaboratedMutate } = useMyProjects("collaborated")
-  const { mutate: myBookmarksMutate } = useMyProjects("bookmarks")
+  // const { mutate: indexMutate } = useProjectList()
+  // const { mutate: myMutate } = useMyProjects("my_projects")
+  // const { mutate: myCollaboratingMutate } = useMyProjects("collaborating")
+  // const { mutate: myCollaboratedMutate } = useMyProjects("collaborated")
+  // const { mutate: myBookmarksMutate } = useMyProjects("bookmarks")
 
   // 動的getKey取得
   const getKeyByCategory = (category: string | undefined) => {
@@ -74,37 +74,37 @@ export const useApplyMutate = () => {
     // SWRinfinity全体の再フェッチを強制
   const revalidateAllLists = async () => {
     console.log("一覧ページ全体の再フェッチ実行");
-    await Promise.all([
-      indexMutate (undefined, { revalidate: false }),
-      myMutate (undefined, { revalidate: true }),
-      myCollaboratingMutate (undefined, { revalidate: false }),
-      myCollaboratedMutate (undefined, { revalidate: false }),
-      myBookmarksMutate (undefined, { revalidate: false }),
-    ])
+    // await Promise.all([
+    //   indexMutate (undefined, { revalidate: false }),
+    //   myMutate (undefined, { revalidate: true }),
+    //   myCollaboratingMutate (undefined, { revalidate: false }),
+    //   myCollaboratedMutate (undefined, { revalidate: false }),
+    //   myBookmarksMutate (undefined, { revalidate: false }),
+    // ])
   };
 
-    //処理主体以外のSWRinfinity全体の再フェッチを強制
-    const revalidateOtherLists = async (category: string | undefined) => {
-      const mutateActions = [];
+    // //処理主体以外のSWRinfinity全体の再フェッチを強制
+    // const revalidateOtherLists = async (category: string | undefined) => {
+    //   const mutateActions = [];
 
-      if (category !== "projects") {
-        mutateActions.push(indexMutate(undefined, { revalidate: false }));
-      }
-      if (category !== "my_projects") {
-        mutateActions.push(myMutate(undefined, { revalidate: false }));
-      }
-      if (category !== "collaborating") {
-        mutateActions.push(myCollaboratingMutate(undefined, { revalidate: false }));
-      }
-      if (category !== "collaborated") {
-        mutateActions.push(myCollaboratedMutate(undefined, { revalidate: false}));
-      }
-      if (category !== "bookmarks") {
-        mutateActions.push(myBookmarksMutate(undefined, { revalidate: false }));
-      }
-      console.log("mutate処理リスト", mutateActions);
-      await Promise.all(mutateActions);
-    };
+    //   if (category !== "projects") {
+    //     mutateActions.push(indexMutate(undefined, { revalidate: false }));
+    //   }
+    //   if (category !== "my_projects") {
+    //     mutateActions.push(myMutate(undefined, { revalidate: false }));
+    //   }
+    //   if (category !== "collaborating") {
+    //     mutateActions.push(myCollaboratingMutate(undefined, { revalidate: false }));
+    //   }
+    //   if (category !== "collaborated") {
+    //     mutateActions.push(myCollaboratedMutate(undefined, { revalidate: false}));
+    //   }
+    //   if (category !== "bookmarks") {
+    //     mutateActions.push(myBookmarksMutate(undefined, { revalidate: false }));
+    //   }
+    //   console.log("mutate処理リスト", mutateActions);
+    //   await Promise.all(mutateActions);
+    // };
 
     //詳細ページ用のmutate
   const applyMutateForShow = async ({
@@ -231,6 +231,6 @@ export const useApplyMutate = () => {
 
       }
     };
-
-    return {applyMutate, revalidateOtherLists, revalidateAllLists};
+    // return {applyMutate, revalidateOtherLists, revalidateAllLists};
+    return {applyMutate,  revalidateAllLists};
   };

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -32,6 +32,7 @@
       "@TopPage/*": ["src/components/TopPage/*"],
       "@User/*": ["src/components/User/*"],
       "@UsersPage/*": ["src/components/UsersPage/*"],
+      "@Notification/*": ["src/components/Notification/*"],
       "@context/*": ["src/context/*"],
       "@audio/*": ["src/hooks/audio/*"],
       "@services/*": ["src/hooks/services/*"],


### PR DESCRIPTION
### Tasks
- [ ] バックエンドの通知モデル等の設定（有効期限は180日に設定）
- [ ] 初回アクセス時の未読エンドポイント作成
- [ ] 通知対象に関するアクションに、DBへ通知情報を保存するメソッドを追加（一部未実装の部分、コメント返信などは考慮に入れず）
- [ ] フロントのcontextで初回アクセス時のリクエストをuseEffectで実装
- [ ] 初回アクセス後の未読判定を、ボトムナビに適用させるロジックの実装
- [ ] 通知ページの画面実装
- [ ] SWRを利用した通知の取得ロジック実装

close #163 