### PR TITLE
SSE実装

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -58,6 +58,10 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "dotenv-rails"
+  gem 'redis', '~> 5.0'
+  gem 'redis-client', '~> 0.23'
+  gem 'connection_pool', '~> 2.5'
+
 end
 
 group :development do

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
       uniform_notifier (~> 1.11)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
+    connection_pool (2.5.0)
     crass (1.0.6)
     csv (3.3.2)
     date (3.4.1)
@@ -258,6 +259,10 @@ GEM
     rake (13.2.1)
     rdoc (6.8.1)
       psych (>= 4.0.0)
+    redis (5.3.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.23.2)
+      connection_pool
     reline (0.5.12)
       io-console (~> 0.5)
     responders (3.1.1)
@@ -293,6 +298,7 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap
   bullet
+  connection_pool (~> 2.5)
   debug
   devise_token_auth
   dotenv-rails
@@ -306,6 +312,8 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.8, >= 7.0.8.6)
+  redis (~> 5.0)
+  redis-client (~> 0.23)
   sendinblue (~> 2.4)
   tzinfo-data
 

--- a/back/app/controllers/api/v1/notifications_stream_controller.rb
+++ b/back/app/controllers/api/v1/notifications_stream_controller.rb
@@ -1,0 +1,56 @@
+require Rails.root.join('lib', 'sse')
+class Api::V1::NotificationsStreamController < ApplicationController
+  include ActionController::Live #Pumaのマルチスレッド機能を利用
+  before_action :authenticate_user!
+  skip_after_action :update_auth_header
+
+  def stream
+    Rails.logger.info "🚀 stream アクション開始"
+
+    Rails.logger.info "✅ 認証ユーザー: #{current_user.id}"
+
+    response.headers['Content-Type'] = 'text/event-stream'
+    response.headers['Cache-Control'] = 'no-cache'
+    response.headers['X-Accel-Buffering'] = 'no'
+
+    Rails.logger.info "🛠 SSE ヘッダー設定: #{response.headers.inspect}"
+
+    sse = SSE.new(response.stream)
+
+    begin
+      # 初回メッセージ送信
+      sse.write({ event: "connection_established", data: "SSE 接続成功" }.to_json)
+      Rails.logger.info "📡 初回メッセージ送信: SSE 接続成功"
+
+      # デバッグ: 5秒ごとに ping を送信
+      loop do
+        break if response.stream.closed?
+        sleep 5
+        begin
+          sse.write({ event: "ping", data: "サーバーは生きている" }.to_json)
+          Rails.logger.info "📡 デバッグ送信: ping"
+        rescue IOError => e
+          Rails.logger.error "🔴 SSE 接続がクローズされました: #{e.message}"
+          break
+        end
+      end
+      
+
+      # Redis の Pub/Sub をリッスン
+      $redis.subscribe("user:#{current_user.id}:has_unread") do |on|
+        on.message do |channel, message|
+          Rails.logger.info "📩 フロントに送信: #{message}"
+          sse.write({ event: "new_notification", data: message }.to_json)
+        end
+      end
+    rescue IOError => e
+      Rails.logger.error "🔴 SSE 接続がクローズされました: #{e.message}"
+    rescue StandardError => e
+      Rails.logger.error "❌ SSE の予期しないエラー: #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+    ensure
+      Rails.logger.info "🔚 SSE ストリーム終了"
+      sse.close
+    end
+  end
+end

--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -26,14 +26,21 @@ module App
     config.session_store :cookie_store, key: '_interslice_session'
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CookieStore, config.session_options
+    config.middleware.delete Rack::Lock
+
     config.action_dispatch.cookies_same_site_protection = :none
 
     config.force_ssl = true
 
+    # SSE のための `lib` 読み込み
+    config.eager_load_paths << Rails.root.join('lib')
+
+    # API モードのまま一部ミドルウェアを追加
+    config.api_only = true
+    config.middleware.insert_before 0, Rack::Sendfile
 
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
-    config.api_only = true
   end
 end

--- a/back/config/environments/development.rb
+++ b/back/config/environments/development.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   config.cache_classes = false
 
   # Do not eager load code on boot.
-  config.eager_load = false
+  config.eager_load = true
 
   # Show full error reports.
   config.consider_all_requests_local = true
@@ -24,21 +24,35 @@ Rails.application.configure do
   # Enable server timing
   config.server_timing = true
 
+  # Redisのキャッシュ設定
+  config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] || 'redis://localhost:6379/1' }
+  config.public_file_server.headers = {
+  "Cache-Control" => "public, max-age=#{2.days.to_i}"
+}
+  config.session_store :cache_store, key: "_jammy_session"
+
+  # ActionController::Live を使用するための設定
+  config.allow_concurrency = true
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join("tmp/caching-dev.txt").exist?
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
-    }
-  else
-    config.action_controller.perform_caching = false
+  # if Rails.root.join("tmp/caching-dev.txt").exist?
+  #   config.cache_store = :memory_store
+  #   config.public_file_server.headers = {
+  #     "Cache-Control" => "public, max-age=#{2.days.to_i}"
+  #   }
+  # else
+  #   config.action_controller.perform_caching = false
 
-    config.cache_store = :null_store
-  end
+  #   config.cache_store = :null_store
+  # end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :amazon
+
+  # Resid関係設定
+  config.action_cable.url = "redis://localhost:6379/1"
+  config.action_cable.allowed_request_origins = ["https://localhost:8000", "http://localhost:8000"]
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/back/config/environments/production.rb
+++ b/back/config/environments/production.rb
@@ -2,6 +2,21 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  # Redis のキャッシュ設定
+  config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
+
+  # SSLが必要な場合
+  # config.cache_store = :redis_cache_store, {
+  #   url: ENV['REDIS_URL'],
+  #   ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  # }
+
+
+  # セッションストアも Redis に設定
+  config.session_store :cache_store, key: "_jammy_session"
+  # ActionCable の Redis 設定
+  config.action_cable.url = ENV['REDIS_URL']
+  config.action_cable.allowed_request_origins = ["https://jam-my.com"]
 
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/back/config/initializers/devise_token_auth.rb
+++ b/back/config/initializers/devise_token_auth.rb
@@ -6,6 +6,7 @@ DeviseTokenAuth.setup do |config|
   # this to false to prevent the Authorization header from changing after
   # each request.
   config.change_headers_on_each_request = false
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.

--- a/back/config/initializers/redis.rb
+++ b/back/config/initializers/redis.rb
@@ -1,0 +1,4 @@
+require 'redis'
+
+$redis = Redis.new(url: ENV['REDIS_URL'] || 'redis://localhost:6379')
+

--- a/back/config/puma.rb
+++ b/back/config/puma.rb
@@ -8,11 +8,21 @@ stdout_redirect nil, nil, true
 max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
+#デバック時はコメントアウト
+
+# max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 1 }
+# min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { 1 }
+# threads min_threads_count, max_threads_count
+# デバック時は追加
+
+# # Worker モードを有効にする（Puma のマルチプロセスモード）デバック時は追加
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.
 #
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+# #↑デバック時はコメントアウト
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
@@ -20,10 +30,10 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+# environment ENV.fetch("RAILS_ENV") { "development" } #デバック時はコメントアウト
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+# pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
           get :has_unread
         end
       end
+      get "notifications/stream", to: "notifications_stream#stream"
     end
   end
 end

--- a/back/lib/sse.rb
+++ b/back/lib/sse.rb
@@ -1,0 +1,16 @@
+require 'json'
+
+class Sse
+  def initialize(stream)
+    @stream = stream
+  end
+
+  def write(data, options = {})
+    @stream.write("data: #{JSON.dump(data)}\n\n")
+    @stream.flush
+  end
+
+  def close
+    @stream.close
+  end
+end

--- a/back/test/controllers/api/v1/notifications_stream_controller_test.rb
+++ b/back/test/controllers/api/v1/notifications_stream_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::NotificationsStreamControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,13 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  redis:
+    image: redis:latest
+    restart: always
+    ports:
+      - "6379:6379"
+
+
   back:
     build:
       context: ./back
@@ -17,6 +24,7 @@ services:
     environment:
       - NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/ca.crt
       - RAILS_ENV=development
+      - REDIS_URL=redis://redis:6379
     volumes:
       - ./back:/app
       - ./back/ca.crt:/usr/local/share/ca-certificates/ca.crt
@@ -26,6 +34,7 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      - redis
     tty: true
     stdin_open: true
 

--- a/front/src/components/Notification/NotificationListWrapper.tsx
+++ b/front/src/components/Notification/NotificationListWrapper.tsx
@@ -1,13 +1,25 @@
 "use client";
 
 import { Box, CircularProgress, Typography, Alert } from "@mui/material";
+import { useEffect } from "react";
 import { NotificationList } from "@Notification/NotificationList";
 import { useNotifications } from "@swr/useNotificationsSWR";
+import { useNotificationContext } from "@context/useNotificationContext";
 
 
 export const NotificationListWrapper = () => {
-  const { notifications, isLoading, isValidating, isError } = useNotifications();
+  const { hasUnread, setHasUnread } = useNotificationContext();
+  const { notifications, isLoading, isValidating, isError, mutate } = useNotifications();
   console.log("notifications", notifications);
+
+  //未読があれば再フェッチ
+  useEffect(() => {
+    if ( hasUnread ) {
+      mutate(undefined, { revalidate: true });
+      setHasUnread(false);
+    }
+  }, []);
+
 
   if (isError) {
     return (


### PR DESCRIPTION
### Tasks
- [x] バックエンドのRedis設定
- [x] バックエンドのSSE設定
- [x] 通知対象アクションに対し、実行時にRedisに通知フラグを設定（通知の有無のみを管理）
- [x] フロントエンドのcontextでSSEのイベント送信をリッスン、疎通確認
- [x] contextで、得た未読有無を初回アクセス時の実装を行った状態変数へ繰り入れ
- [x] リッスンした場合に、通知用SWRへ再フェッチ指示のmutateを定義

フロントがメッセージを受信できない問題については別イシューで取り組み

close #118 