### PR TITLE
rails middleware 実行順序指定

### DIFF
--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -24,8 +24,8 @@ module App
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     # config.eager_load_paths << Rails.root.join("extras")
     config.session_store :cookie_store, key: '_interslice_session'
-    config.middleware.use ActionDispatch::Cookies
-    config.middleware.use ActionDispatch::Session::CookieStore, config.session_options
+    config.middleware.insert_before Warden::Manager, ActionDispatch::Cookies
+    config.middleware.insert_before Warden::Manager, ActionDispatch::Session::CookieStore, config.session_options
     config.middleware.delete Rack::Lock
 
     config.action_dispatch.cookies_same_site_protection = :none

--- a/back/config/initializers/cors.rb
+++ b/back/config/initializers/cors.rb
@@ -5,7 +5,7 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-Rails.application.config.middleware.insert_before 0, Rack::Cors do
+Rails.application.config.middleware.insert_before Warden::Manager, Rack::Cors do
   allow do
     origins "https://localhost:8000", "https://127.0.0.1:8000", "https://jam-my.com", "https://www.jam-my.com"
 


### PR DESCRIPTION
### 対応項目
- [ ] グーグル認証成功後、ブラウザがクッキーを保存しない問題について、原因は不明であるが、Rails側のmiddlewareの実行順を見直し。具体的にはcookie関連、およびcorsをWarden::Managerの前に設置する事で開発環境での正常な動作を確認したもの。
