### PR TITLE
devise_token_authの設定ファイル修正

### DIFF
--- a/back/config/initializers/devise_token_auth.rb
+++ b/back/config/initializers/devise_token_auth.rb
@@ -78,7 +78,7 @@ DeviseTokenAuth.setup do |config|
     secure: true ,
     httponly: true,
     same_site: :none,
-    expires: 1.day.from_now,
+    expires: 1.day,
     domain: ENV.fetch("COOKIE_DOMAIN", "localhost")
   }
 


### PR DESCRIPTION
### 対応項目
- [ ] クッキーが削除されてしまう問題について調査→devise_token_authの設定ファイルにて、クッキーの期限設定に1.day.from_nowを指定しており、すなわちサーバーが起動した時点の固定された日時から起算して期限設定を行ってしまっている事が判明
- [ ] 1.dayに変更。