### PR TITLE
Issue223 fix audio logic5

### DIFF
--- a/front/src/components/Project/AudioController.tsx
+++ b/front/src/components/Project/AudioController.tsx
@@ -22,11 +22,26 @@ export function AudioController({
   user: User | null
   audioElement: HTMLAudioElement | null
 }){
-  const { isPlaying, currentTime, duration, play, pause, seek } = useProjectIndexAudioPlayer(audioElement);
+  const { isPlaying, isPlayingRef, currentTime, duration, play, pause, seek } = useProjectIndexAudioPlayer(audioElement);
 
   useEffect(() => {
     play(); //初回レンダリング時のみ自動再生
   }, [audioData]);
+
+  //タブが非アクティブになった場合
+  useEffect(() => {
+    const handleVisibilityChange = () =>{
+      if(document.hidden && isPlayingRef){ //タブを離れた場合かつ再生中のみ
+        pause(); //停止ボタン処理
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return() =>{
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  },[])
 
   return(
     <Box

--- a/front/src/components/Project/core_logic/AudioPlayer.tsx
+++ b/front/src/components/Project/core_logic/AudioPlayer.tsx
@@ -22,7 +22,6 @@ export function AudioPlayer({
   enablePostAudioPreview?: boolean; //オプショナル
 }){
 // console.log(`[id:${id}!]enablePostAudioPreviewの追跡`,enablePostAudioPreview);
-console.log("プレイヤーが受け取ったaudioBuffer", audioBuffer);
 
   //同時再生Context
   const {
@@ -39,6 +38,7 @@ console.log("プレイヤーが受け取ったaudioBuffer", audioBuffer);
 
   const {
     isPlayingRef,
+    setIsPlaying,
     init,
     resetPlaybackState,
     play,
@@ -88,7 +88,23 @@ console.log("プレイヤーが受け取ったaudioBuffer", audioBuffer);
     };
   }, []);
 
+  //タブが非アクティブになった場合
+  useEffect(() => {
+    if(!audioContext) return;
 
+    const handleVisibilityChange = async () =>{
+      if(document.hidden && isPlayingRef.current){ //タブを離れた場合かつ再生中の場合のみ
+        await handlePlayPause(); //停止ボタン処理
+      } else if(!document.hidden){ //戻ってきた場合
+        resetPlaybackState();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return() =>{
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  },[])
 
 
   // 音声間の再生・停止指示リスナー、停止制御

--- a/front/src/hooks/audio/useAudioPlayer.ts
+++ b/front/src/hooks/audio/useAudioPlayer.ts
@@ -33,6 +33,7 @@ export function useAudioPlayer({
 
   // console.log("currentTime追跡", currentTime);
   // console.log("isPlaying追跡", isPlaying);
+  // console.log("isPlayingRef追跡", isPlayingRef.current);
   // console.log("duration追��", duration);
   // console.log("sourceNodeRef.current追跡", sourceNodeRef.current);
   // console.log("startTimeRef.current追跡", startTimeRef.current);
@@ -131,14 +132,8 @@ export function useAudioPlayer({
 
   //再生
   const play = (): void => {
-    // console.log(`[id:${id}!]再生直前のisPlayingRef追跡`,isPlayingRef.current);
-    // console.log(`[id:${id}!]再生直前のisPlaybackTriggered追跡`, isPlaybackTriggered);
-    // console.log(`[id:${id}!]再生直前のplaybackTriggeredByRef追跡`, playbackTriggeredByRef.current);
+    // console.log("Playの呼び出し");
     if (audioContext) {
-      // console.log(`[id:${id}] 再生開始前のsourceNodeRef:`, sourceNodeRef.current);
-      // console.log(`[id:${id}] AudioContext state:`, audioContext.state);
-      // console.log(`[id:${id}] 再生開始前のGainNode接続状況:`, gainNode);
-
       ignoreOnEndedForPauseRef.current = false; //onendedイベントを阻害しないように、制御フラグをリセット
 
       if (sourceNodeRef.current) {
@@ -244,6 +239,7 @@ export function useAudioPlayer({
 
   return {
     isPlayingRef: isPlayingRef,
+    setIsPlaying,
     currentTime,
     duration,
     init,

--- a/front/src/hooks/audio/useAudioRecorder.ts
+++ b/front/src/hooks/audio/useAudioRecorder.ts
@@ -81,11 +81,11 @@ export function useAudioRecorder({
       // console.log("マイク入力を取得開始");
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: {
-          // sampleRate: 44100,
-          // channelCount: 1, //モノラル
-          // echoCancellation: false, //エコーキャンセルオフ
-          // noiseSuppression: false, //ノイズキャンセリングオフ
-          // autoGainControl: false, //自動ゲイン調整をオフ
+          sampleRate: 44100,
+          channelCount: 1, //モノラル
+          echoCancellation: false, //エコーキャンセルオフ
+          noiseSuppression: false, //ノイズキャンセリングオフ
+          autoGainControl: false, //自動ゲイン調整をオフ
           deviceId: { exact: micId } },
       });
       //以上のオプションは録音時のマイク遅延を減らす為に前もって設定するもの

--- a/front/src/hooks/audio/useProjectIndexAudioPlayer.ts
+++ b/front/src/hooks/audio/useProjectIndexAudioPlayer.ts
@@ -5,6 +5,13 @@ export function useProjectIndexAudioPlayer(audioElement: HTMLAudioElement | null
   const [currentTime, setCurrentTime] = useState<number>(0);
   const [duration, setDuration] = useState<number>(0);
 
+  const isPlayingRef = useRef<boolean>(false);
+
+  //isPlayingRefとisPlayingの同期（イベントリスナーによるStateの固定化(クロージャー)を避けるため、isPlayingRefを使用）
+  useEffect(() => {
+    isPlayingRef.current = isPlaying;
+  },[isPlaying]);
+
   useEffect(() => {
     if (!audioElement) return;
 
@@ -31,13 +38,13 @@ export function useProjectIndexAudioPlayer(audioElement: HTMLAudioElement | null
   }, []); //選択されたaudioDataが変わる度に再初期化
 
   const play = ():void=> {
-    audioElement?.play();
     setIsPlaying(true);
+    audioElement?.play();
   };
 
   const pause = ():void => {
-    audioElement?.pause();
     setIsPlaying(false);
+    audioElement?.pause();
   };
 
   const seek = (time: number):void => {
@@ -49,6 +56,7 @@ export function useProjectIndexAudioPlayer(audioElement: HTMLAudioElement | null
 
   return {
     isPlaying,
+    isPlayingRef,
     currentTime,
     duration,
     play,


### PR DESCRIPTION
### 対応項目
- [ ] AudioControllerおよび、AudioSourceBufferNodeを利用した音声再生中にタブ移動を行った場合に音声を停止するロジックの追加
- [ ] マイク取得時の設定を変更
- [ ] 応募管理で初回にマイク取得のみ行うロジック追加

### 留意事項
- マイクについては、サンプルレート、チャンネル数をあらかじめ指定し録音中の不必要な変換を防止。また、エコー、ノイズキャンセル、自動ゲイン調整をオフにする事で、録音自体の遅延に対応。ただし、これにより録音音声の音量が小さくなってしまったのと、デバイスを網羅的にテストできていない為、今後の挙動に注視
- 応募管理で初回に必ずマイク取得を行う理由について。前提としてiOSでは、マイク取得を行うと、デバイスのミュートスイッチを無視して音声を再生するという迷惑な仕様がある。これは現在のところ回避不能であり、マイク取得を行わない応募管理については、逆にミュートスイッチに準じる形となる為、ユーザーに混乱をもたらす。現実的にはミュートスイッチを無視するという挙動に合わせるしかなく、仕様変更を待つ必要があるもの。
- AudioControllerについては、軽量化の観点からこれだけHTMLAudioElementを利用して再生を行っている。これについては、デフォルトでミュートスイッチを無視する。

close #223 