### PR TITLE
試験的にAudioSessionAPIを導入

### DIFF
--- a/front/src/components/CollaborationManagement/CollaborationManagementStepper.tsx
+++ b/front/src/components/CollaborationManagement/CollaborationManagementStepper.tsx
@@ -10,6 +10,7 @@ import { CollaborationManagementStep3 } from "@CollaborationManagement/Collabora
 import { useProjectContext } from "@context/useProjectContext";
 import { collaborationManagementIndexRequest } from "@services/project/collaboration_management/useCollaborationManagementIndexRequest";
 import { PlaybackProvider } from "@context/usePlayBackContext";
+import { useSettingAudioSession } from "@utils/useSettingAudioSession";
 
 
 const steps = ["応募選択/編集", "音声合成", "保存"];
@@ -24,6 +25,8 @@ export function CollaborationManagementStepper(){
   //管理対象のProject/User情報(Context)
   const { currentProject, setCurrentProject, currentUser, setCurrentUser,currentAudioFilePath, setCurrentAudioFilePath } = useProjectContext();
 
+  //フック
+  const { settingAudioSession } = useSettingAudioSession();
 
   // データ格納（リロード対策）
   useEffect(() => {
@@ -91,6 +94,7 @@ export function CollaborationManagementStepper(){
   //AudioContextの初期化
   useEffect(() => {
     const initializeAudioContext = async () => {
+      settingAudioSession();
       globalAudioContextRef.current = new (window.AudioContext || (window as any).webkitAudioContext)({
         sampleRate: 44100
       });

--- a/front/src/components/Project/core_logic/RecordingCore.tsx
+++ b/front/src/components/Project/core_logic/RecordingCore.tsx
@@ -37,6 +37,7 @@ export function RecordingCore({
   const [loading, setLoading] = useState<boolean>(false); // ローディング状態
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+  const [initializedDeviceId, setInitializedDeviceId] = useState<string | null>(null);
   const [isPressed, setIsPressed] = useState(false);
   const [openDialog, setOpenDialog] = useState<boolean>(false);
 
@@ -62,6 +63,7 @@ export function RecordingCore({
     mediaStreamSourceRef,
     setLoading,
     setIsRecording,
+    setInitializedDeviceId,
     cleanupAnalyzer,
     stopMetronome,
     setIsPlaybackTriggered,
@@ -142,14 +144,6 @@ export function RecordingCore({
 
   //レンダリング時に初期化関数実行
   useEffect(() => {
-    // console.log(`[${new Date().toISOString()}] RecordingCoreがマウントされました`);
-    // console.log("RecordingCore: 初期化前のAudioContextの状態", audioContextRef.current?.state);
-    // console.log("RecordingCore: 初期化前のMediaStreamSourceの状態", mediaStreamSourceRef.current);
-    // console.log("RecordingCore: 初期化前のaudioWorkletNodeRefの状態", audioWorkletNodeRef.current);
-    // console.log("RecordingCore: 初期化前のclickSoundBufferRefの状態", clickSoundBufferRef.current);
-    // console.log("RecordingCore: 初期化状態のフラグ (isInitialized):", isInitialized);
-    // console.log("RecordingCore: 初期化中のフラグ (isInitializing):", isInitializing);
-
     let isMounted = true; // マウント状態を追跡
 
     //初期化処理
@@ -158,11 +152,7 @@ export function RecordingCore({
     // クリーンアップ処理
     return () => {
       isMounted = false; // アンマウントを記録
-
-      // console.log(`RecordingCoreがアンマウントされました[${new Date().toISOString()}]`);
-      // console.log("RecordingCore: クリーンアップ開始");
       resetInitialization();
-      // console.log("RecordingCore: クリーンアップ完了");
     };
   }, [selectedDeviceId]);
 
@@ -315,7 +305,9 @@ export function RecordingCore({
               2. メトロノームを聞きながら、または投稿の音声を聞きながら録音する際は、できるだけイヤホン・ヘッドホンを利用しましょう！<br />
               <br />
               ※お使いのイヤホンのマイク性能や接続方式（BlueTooth等）によっては、録音音声に遅延が発生することがあります。<br />
-              ※スマホからのご利用の場合（特にiOSの方）、お使いのイヤホンによっては、スピーカー出力とマイク入力を分離できない場合があります。<br />
+              ※スマートフォンでは、マイク付きヘッドホン・イヤホンを利用される場合、ほとんどのケースでマイク選択により音声出力もセットでご指定のデバイスになります。分離して録音したい場合は、マイクなしのイヤホンもしくはPCでのご利用を推奨します。
+              <br />
+              <span style={{color:"#e53935"}}>※iOSユーザーの方はSafariを推奨します。</span>
               </DialogContentText>
             </DialogContent>
           </Dialog>
@@ -329,7 +321,7 @@ export function RecordingCore({
           {microphones.map((mic) => (
             <MenuItem
               key={mic.deviceId}
-              selected={mic.deviceId === selectedDeviceId}
+              selected={(mic.deviceId === selectedDeviceId) || (mic.deviceId ===initializedDeviceId)}
               onClick={() => handleMicSelect(mic.deviceId)}
             >
               {mic.label || `マイク (${mic.deviceId})`}

--- a/front/src/sharedTypes/global.d.ts
+++ b/front/src/sharedTypes/global.d.ts
@@ -1,0 +1,22 @@
+  //AudioSession
+  interface AudioSession{
+    //タイプは以下ユニオン型で定義。一つしか選べない
+    sessionType: "ambient" | "playback" | "voiceCommunication" | "gameChat" | "soloAmbient" | "record" | "moviePlayback" | "spokenAudio";
+    state?: string; //現在のオーディオセッションの状態
+    onstatechange?:()=>void;
+  }
+
+  //ブラウザのnavigatorオブジェクトにaudioSessionを追加。
+  interface Navigator{
+    audioSession?: AudioSession; //未対応ブラウザがある為、オプショナル定義
+  }
+
+  //* stateの補足
+  // "active" = 音声が再生または録音中
+  // "inactive" = オーディをセッションが停止中
+  // "paused" = 一時停止中（ユーザーが音声を一時停止している）
+  // "interrupted" = システムによって中断（他のアプリの通話が割り込むなど）
+  // "closed" = セッションが終了
+
+  //*onstatechangeの補足
+  //stateが変わった時に実行されるイベントハンドラでたとえばinterruptedが起こった時に、音声を停止するなどの処理が可能

--- a/front/src/utils/useSettingAudioSession.ts
+++ b/front/src/utils/useSettingAudioSession.ts
@@ -1,0 +1,15 @@
+  //AudioSessionの設定（試験的利用。2025年3月17日現在ではiOSのsafariのみ対応）
+
+  export const useSettingAudioSession = () => {
+    const settingAudioSession = () =>{
+      //AudioSessionの設定。なければ（Safariでなければ）離脱
+      if("audioSession" in navigator && navigator.audioSession){
+        navigator.audioSession.sessionType = "voiceCommunication";
+        console.log("AudioSessionのState", navigator.audioSession.sessionType);
+      } else{
+        console.info("This Browser does not support AudioSessionAPI");
+        return;
+      }
+    }
+    return {settingAudioSession};
+  };

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -51,7 +51,8 @@
     "next-env.d.ts",
     ".next/types/**/*.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    "src/sharedTypes/**/*.ts",
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
### 対応項目
- [ ] AudioSessionAPIの調査 [https://www.w3.org/TR/audio-session/](w3c)
- [ ] カスタムグローバル型定義ファイルの作成
- [ ] AudioSessionType設定のユーティリティ関数を別ファイルにて作成
- [ ] マイクの初期選択時のセレクト表記の修正
- [ ] 録音時の注意書き編集

### 留意事項
- [ ] iOSにおいて、マイクとスピーカー出力を分ける手段は提供されていない。
- [ ] iOSにおいて、getUserMediaをした時点でシステム音声のルーティングが変わり、通話時の出力音質となる。今回これに対応する為に試験的にAudioSessionを導入。なお、こちらはまだSafariしか対応していない。
- [ ] iOSにおいて、Chromeはルーティングの変更は現状避けられず、音質の劣化と音量減少は避けられない状況。
- [ ] 問題となるのが、一覧ページにおけるHTMLAudioElementを利用した再生や応募管理など、マイク取得を行わない場合。一度マイク取得を行ってしまえば、iOSがOSサウンドレベルで自動変更する為、その2つに関してもモードの適用となるが、初回に2つのアクションを行う場合は、録音関連のコンポーネントの再生時と音量が違うため、ユーザーが違和感を覚える可能性高い。→応募管理のみマイク取得を行った。（これは要検討）。一覧再生時にマイク取得を行うのは良くない。