### PR TITLE
Fix_通知削除漏れ問題への対応

### DIFF
--- a/back/app/models/collaboration.rb
+++ b/back/app/models/collaboration.rb
@@ -11,6 +11,7 @@ class Collaboration < ApplicationRecord
   validates :status, inclusion: { in: statuses.keys }
 
   after_create :create_notification
+  before_destroy :destroy_related_notifications
 
   private
 
@@ -23,5 +24,10 @@ class Collaboration < ApplicationRecord
       notifiable: self,
       notification_type: :collaboration_request
     )
+  end
+
+  # dependent_destroyの実行前に通知の削除を保証する
+  def destroy_related_notifications
+    Notification.where(notifiable: self).destroy_all
   end
 end

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -17,4 +17,14 @@ class Project < ApplicationRecord
   # statusの値保証
   validates :status, inclusion: { in: statuses.keys }
   validates :visibility, inclusion: { in: visibilities.keys }
+
+  before_destroy :destroy_related_notifications
+
+  private
+
+  # dependent_destroyの実行前に通知の削除を保証する
+  def destroy_related_notifications
+    Notification.where(notifiable: self).destroy_all
+    Notification.where(notifiable: collaborations).destroy_all
+  end
 end

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -49,12 +49,12 @@ export const metadata = {
 };
 
 
-// // 本番環境で console.log を無効化
-// if (process.env.NODE_ENV === "production") {
-//   console.log = () => {};
-//   console.warn = () => {}; // 必要なら他のログも無効化
-//   console.error = () => {}; // エラーを隠したい場合
-// }
+// 本番環境で console.log を無効化
+if (process.env.NODE_ENV === "production") {
+  console.log = () => {};
+  console.warn = () => {}; // 必要なら他のログも無効化
+  console.error = () => {}; // エラーを隠したい場合
+}
 
 export default function RootLayout({ children }: Readonly<{
   children: React.ReactNode


### PR DESCRIPTION
### 原因
- [ ] NotifiableがCollaborationの場合に、対象のProjectが削除された際にdependent_destroyでは実行順が保証されず、結果として、関連を辿れず一部の通知が削除されずに残っていた。ここを保証する為には、dependent_destroyよりも前に実行されるbefore_actionにて補助的に削除処理を設置すべき
- [ ] 本番環境にて、問題となっていた通知を手動で削除したところ、500エラーがなくなったので、上記の原因は確定となった

### 対応
- [ ] ProjectモデルおよびCollaborationモデルにおいて、コールバックアクションを補助的に設置

### 結果
- [ ] 通知が残らずに削除されている事を確認したもの

close #245 
